### PR TITLE
BUG. In case of any errors catched before the compiler is built, status-map return silent error [{:message "Corrupted compiler structure"}]

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+# 1.0.2
+FIXED bug issue with silent status-map after error execution.
+
 # 1.0.1 
 Update for cljdocs
 

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 
 [![Clojars Project](https://img.shields.io/clojars/v/org.clojars.funkcjonariusze/commando.svg)](https://clojars.org/org.clojars.funkcjonariusze/commando)
 [![Run tests](https://github.com/funkcjonariusze/commando/actions/workflows/unit_test.yml/badge.svg)](https://github.com/funkcjonariusze/commando/actions/workflows/unit_test.yml)
-[![cljdoc badge](https://cljdoc.org/badge/org.clojars.funkcjonariusze/commando)](https://cljdoc.org/d/org.clojars.funkcjonariusze/commando/1.0.1)
+[![cljdoc badge](https://cljdoc.org/badge/org.clojars.funkcjonariusze/commando)](https://cljdoc.org/d/org.clojars.funkcjonariusze/commando/1.0.2)
 
 **Commando** is a flexible Clojure library for managing, extracting, and transforming data inside nested map structures using a declarative command-based DSL.
 
@@ -30,10 +30,10 @@
 
 ```clojure
 ;; deps.edn with git
-{org.clojars.funkcjonariusze/commando {:mvn/version "1.0.1"}}
+{org.clojars.funkcjonariusze/commando {:mvn/version "1.0.2"}}
 
 ;; leiningen
-[org.clojars.funkcjonariusze/commando "1.0.1"]
+[org.clojars.funkcjonariusze/commando "1.0.2"]
 ```
 
 ## Quick Start

--- a/pom.xml
+++ b/pom.xml
@@ -4,7 +4,7 @@
   <packaging>jar</packaging>
   <groupId>org.clojars.funkcjonariusze</groupId>
   <artifactId>commando</artifactId>
-  <version>1.0.1</version>
+  <version>1.0.2</version>
   <name>commando</name>
   <dependencies>
     <dependency>
@@ -42,6 +42,6 @@
     <url>https://github.com/funkcjonariusze/commando</url>
     <connection>scm:git:git://github.com/funkcjonariusze/commando.git</connection>
     <developerConnection>scm:git:ssh://git@github.com:funkcjonariusze/commando.git</developerConnection>
-    <tag>1.0.1</tag>
+    <tag>1.0.2</tag>
   </scm>
 </project>

--- a/src/commando/core.cljc
+++ b/src/commando/core.cljc
@@ -157,7 +157,7 @@
       :ok (cond-> status-map
             true (update-in [:registry] registry/detach-instruction-commands)
             true (update-in [:internal/cm-running-order] registry/remove-instruction-commands-from-command-vector)
-            (false? utils/*debug-mode*) (select-keys [:status :registry :internal/cm-running-order])))))
+            (false? utils/*debug-mode*) (select-keys [:status :registry :internal/cm-running-order :successes :warnings])))))
 
 (defn ^:private compiler->status-map
   "Cause compiler contains only two :registry and :internal/cm-running-order keys
@@ -169,9 +169,9 @@
     (case (:status compiler)
       :ok (if (true? utils/*debug-mode*)
             (-> (smap/status-map-pure compiler))
-            (-> (smap/status-map-pure (select-keys compiler [:registry :internal/cm-running-order]))))
+            (-> (smap/status-map-pure (select-keys compiler [:registry :internal/cm-running-order :successes :warnings]))))
       :failed compiler)
-    (-> (smap/status-map-pure)
+    (-> (smap/status-map-pure compiler)
         (smap/status-map-handle-error {:message "Corrupted compiler structure"}))))
 
 (defn execute

--- a/test/unit/commando/core_test.cljc
+++ b/test/unit/commando/core_test.cljc
@@ -1144,7 +1144,15 @@
     (is (commando/failed? (commando/execute [invalid-cmd] invalid-validation-instruction)) "Invalid command validation")
     (is (commando/failed? (commando/execute [throwing-cmd] throwing-recognition-instruction))
         "Command recognition exception")
-    (is (commando/failed? (commando/execute [cmds-builtin/command-from-spec] unexisting-path-instruction)))
+    (let [result (commando/execute [cmds-builtin/command-from-spec] unexisting-path-instruction)]
+      (is (commando/failed? result))
+      (is (=
+            (:errors result)
+            [{:message
+              "Commando. Point dependency failed: key ':commando/from' references non-existent path [\"UNEXISTING_PATH\"]",
+              :path ["2" :container],
+              :command {:commando/from ["UNEXISTING_PATH"]}}
+             {:message "Corrupted compiler structure"}])))
     (is (commando/failed? (commando/execute [cmds-builtin/command-apply-spec] {"plain" {:commando/apply [1 2 3]}}))
         "Missing := parameter causes validation failure"))
   (testing "Basic cases"


### PR DESCRIPTION
FIX the compiler map siliense while the error is occured. Added to successfull status-map messages about the compiler :successes and :warnings messages. For error map added information about the :errors