### PR TITLE
Fixing function argument for builtin command-specs. Upgrade  :validate-params-fn behavior. Better error structures for clj/cljs

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@
 [![Run tests](https://github.com/funkcjonariusze/commando/actions/workflows/unit_test.yml/badge.svg)](https://github.com/funkcjonariusze/commando/actions/workflows/unit_test.yml)
 [![cljdoc badge](https://cljdoc.org/badge/org.clojars.funkcjonariusze/commando)](https://cljdoc.org/d/org.clojars.funkcjonariusze/commando/1.0.2)
 
-**Commando** is a flexible Clojure library for managing, extracting, and transforming data inside nested map structures using a declarative command-based DSL.
+**Commando** is a flexible Clojure library for managing, extracting, and transforming data inside nested map structures aimed to build your own Data DSL.
 
 ## Content
 
@@ -265,8 +265,8 @@ Let's create a new command using a CommandMapSpec configuration map:
 ```
 
 - `:type` - a unique identifier for this command.
-- `:recognize` - a predicate that recognizes that a structure `{:CALC= ...}` is a command, not just a generic map.
-- `:validate-params` (optional) - validates the structure after recognition.
+- `:recognize-fn` - a predicate that recognizes that a structure `{:CALC= ...}` is a command, not just a generic map.
+- `:validate-params-fn` (optional) - validates the structure after recognition.
 - `:apply` - the function that directly executes the command as params it receives whole instruction, command spec and as a last argument what was recognized by :cm/recognize
 - `:dependencies` - describes the type of dependency this command has. Commando supports three modes:
   - `{:mode :all-inside}` - the command scans itself for dependencies on other commands within its body.
@@ -320,7 +320,7 @@ The concept of a **command** is not limited to map structures it is basically an
 ```clojure
 (commando/execute
   [{:type :custom/json
-	:recognize #(and (string? %) (clojure.string/starts-with? % "json"))
+	:recognize-fn #(and (string? %) (clojure.string/starts-with? % "json"))
 	:apply (fn [_instruction _command-map string-value]
               (clojure.data.json/read-str (apply str (drop 4 string-value))
 				:key-fn keyword))

--- a/src/commando/commands/builtin.cljc
+++ b/src/commando/commands/builtin.cljc
@@ -2,77 +2,107 @@
   (:require
    [commando.impl.dependency :as deps]
    [commando.impl.utils :as utils]
-   [malli.core :as malli]))
+   [malli.core :as malli]
+   [malli.error]))
 
 (def command-fn-spec
   {:type :commando/fn
    :recognize-fn #(and (map? %) (contains? % :commando/fn))
    :validate-params-fn (fn [m]
-                            (malli/validate [:map
-                                             [:commando/fn fn?]
-                                             [:args {:optional true}
-                                              coll?]]
-                                            m))
+                         (if-let [m-explain
+                                  (malli.error/humanize
+                                    (malli/explain
+                                      [:map
+                                       [:commando/fn utils/ResolvableFn]
+                                       [:args {:optional true} coll?]]
+                                      m))]
+                           m-explain
+                           true))
    :apply (fn [_instruction _command-map m]
-               (let [m-fn (:commando/fn m) m-args (:args m []) result (apply m-fn m-args)] result))
+            (let [m-fn (utils/resolve-fn (:commando/fn m))
+                  m-args (:args m [])
+                  result (apply m-fn m-args)] result))
    :dependencies {:mode :all-inside}})
 
 (def command-apply-spec
   {:type :commando/apply
    :recognize-fn #(and (map? %) (contains? % :commando/apply))
-   :validate-params-fn (fn [m] (malli/validate [:map [:commando/apply :some] [:= [:or fn? :keyword]]] m))
+   :validate-params-fn (fn [m]
+                         (if-let [m-explain
+                                  (malli.error/humanize
+                                    (malli/explain
+                                      [:map [:commando/apply :any]
+                                       [:= utils/ResolvableFn]] m))]
+                           m-explain
+                           true))
    :apply (fn [_instruction _command-path-obj command-map]
-               (let [result (:commando/apply command-map)
-                     result (let [m-= (:= command-map)] (if m-= (m-= result) result))]
-                 result))
+            (let [result (:commando/apply command-map)
+                  result (let [m-= (utils/resolve-fn (:= command-map))] (if m-= (m-= result) result))]
+              result))
    :dependencies {:mode :all-inside}})
+
 
 (def command-from-spec
   {:type :commando/from
    :recognize-fn #(and (map? %) (contains? % :commando/from))
    :validate-params-fn (fn [m]
-                            (malli/validate [:map
-                                             [:commando/from [:sequential [:or :string :keyword :int]]]
-                                             [:= {:optional true}
-                                              [:or fn? :keyword :string]]]
-                                            m))
+                         (if-let [m-explain
+                                  (malli.error/humanize
+                                    (malli/explain [:map
+                                                    [:commando/from 
+                                                     [:sequential {:error/message "commando/from should be a sequence path to value in Instruction: [:some 2 \"value\"]"}
+                                                      [:or :string :keyword :int]]]
+                                                    [:= {:optional true} [:or utils/ResolvableFn :string]]]
+                                      m))]
+                           m-explain
+                           true))
    :apply (fn [instruction command-path-obj command-map]
-               (let [path-to-another-command (deps/point-target-path instruction command-path-obj)
-                     result (get-in instruction path-to-another-command)
-                     result (let [m-= (:= command-map)]
-                              (if m-= (if (string? m-=) (get result m-=) (m-= result)) result))]
-                 result))
+            (let [path-to-another-command (deps/point-target-path instruction command-path-obj)
+                  result (get-in instruction path-to-another-command)
+                  result (let [m-= (:= command-map)]
+                           (if m-= (if (string? m-=)
+                                     (get result m-=)
+                                     (let [m-= (utils/resolve-fn m-=)]
+                                       (m-= result))) result))]
+              result))
    :dependencies {:mode :point
-                     :point-key :commando/from}})
+                  :point-key :commando/from}})
 
 (def command-from-json-spec
   {:type :commando/from-json
    :recognize-fn #(and (map? %) (contains? % "commando-from"))
-   :validate-params-fn (fn [m] (malli/validate [:map
-                                                  ["commando-from" [:sequential [:or :string :int]]]
-                                                  ["=" {:optional true} [:string {:min 1}]]] m))
+   :validate-params-fn (fn [m]
+                         (if-let [m-explain
+                                  (malli.error/humanize
+                                    (malli/explain [:map
+                                                    ["commando-from"
+                                                     [:sequential {:error/message "commando-from should be a sequence path to value in Instruction: [\"some\" 2 \"value\"]"}
+                                                      [:or :string :int]]]
+                                                    ["=" {:optional true} [:string {:min 1}]]] m))]
+                           m-explain
+                           true))
    :apply (fn [instruction command-path-obj command-map]
-               (let [path-to-another-command (deps/point-target-path instruction command-path-obj)
-                     result (get-in instruction path-to-another-command)
-                     result (if-let [m-= (get command-map "=")]
-                              (if (string? m-=)
-                                (get result m-=)
-                                result)
-                              result)]
-                 result))
+            (let [path-to-another-command (deps/point-target-path instruction command-path-obj)
+                  result (get-in instruction path-to-another-command)
+                  result (if-let [m-= (get command-map "=")]
+                           (if (string? m-=)
+                             (get result m-=)
+                             result)
+                           result)]
+              result))
    :dependencies {:mode :point
-                     :point-key "commando-from"}})
+                  :point-key "commando-from"}})
 
 (defmulti command-mutation (fn [tx-type _data] tx-type))
 (defmethod command-mutation :default
   [undefined-tx-type _]
   (throw (ex-info (str utils/exception-message-header
-                       "command-mutation. Undefined "
-                       undefined-tx-type
-                       " type '"
-                       undefined-tx-type
-                       "'")
-                  {:commando/mutation undefined-tx-type})))
+                    "command-mutation. Undefined "
+                    undefined-tx-type
+                    " type '"
+                    undefined-tx-type
+                    "'")
+           {:commando/mutation undefined-tx-type})))
 
 ;; in mutation underscore what is occur in example
 ;; understand why command-from-spec
@@ -83,17 +113,27 @@
 (def command-mutation-spec
   {:type :commando/mutation
    :recognize-fn #(and (map? %) (contains? % :commando/mutation))
-   :validate-params-fn (fn [m] (malli/validate [:map [:commando/mutation :keyword]] m))
+   :validate-params-fn (fn [m]
+                         (if-let [m-explain (malli.error/humanize
+                                              (malli/explain [:map [:commando/mutation :keyword]] m))]
+                           m-explain
+                           true))
    :apply (fn [_instruction _command-map m]
-               (let [m-tx-type (:commando/mutation m) m (dissoc m :commando/mutation)]
-                 (command-mutation m-tx-type m)))
+            (let [m-tx-type (:commando/mutation m) m (dissoc m :commando/mutation)]
+              (command-mutation m-tx-type m)))
    :dependencies {:mode :all-inside}})
 
 (def command-mutation-json-spec
   {:type :commando/mutation-json
    :recognize-fn #(and (map? %) (contains? % "commando-mutation"))
-   :validate-params-fn (fn [m] (malli/validate [:map ["commando-mutation" [:string {:min 1}]]] m))
+   :validate-params-fn (fn [m]
+                         (if-let [m-explain (malli.error/humanize
+                                              (malli/explain [:map ["commando-mutation" [:string {:min 1}]]] m))]
+                           m-explain
+                           true))
    :apply (fn [_instruction _command-map m]
-               (let [m-tx-type (get m "commando-mutation") m (dissoc m "commando-mutation")] (command-mutation m-tx-type m)))
+            (let [m-tx-type (get m "commando-mutation") m (dissoc m "commando-mutation")] (command-mutation m-tx-type m)))
    :dependencies {:mode :all-inside}})
+
+
 

--- a/src/commando/core.cljc
+++ b/src/commando/core.cljc
@@ -27,8 +27,13 @@
 
    Additional optional keys can include:
    - `:validate-params-fn` - a function to validate command structures, and catch 
-          invalid parameters at the anylisis stage
-          (fn [command-map-obj] (if valid-params? command-map-obj (throw ...))
+          invalid parameters at the anylisis stage. Only if the function 
+          return 'true' it ment that the command structure is valid.
+          (fn [data] (throw ...))        => Failure
+          (fn [data] {:reason \"why\"})  => Failure
+          (fn [data] nil )               => Failure
+          (fn [data] false )             => Failure
+          (fn [data] true )              => OK
 
    The function returns a built registry that can be used to resolve Instruction 
   

--- a/src/commando/impl/utils.cljc
+++ b/src/commando/impl/utils.cljc
@@ -1,10 +1,10 @@
-(ns commando.impl.utils)
+(ns commando.impl.utils
+  (:require [malli.core :as malli]))
 
 (def exception-message-header "Commando. ")
 
 (def ^:dynamic *debug-mode*
-  "Debug mode flag controlled by COMMANDO_DEBUG environment variable.
-   When enabled, debug-stack-map functionality is active in find-commands*."
+  "When enabled, debug-stack-map functionality is active in find-commands*."
   false)
 
 (def ^{:dynamic true
@@ -25,12 +25,53 @@
     (nil? e) nil
     #?(:clj (instance? Throwable e)
        :cljs (instance? js/Error e))
-    #?(:clj (Throwable->map e)
-       :cljs (cond-> {:message (.-message e)
-                      :type (.. e -constructor -name)}
-               ;; Add data if this is an ExceptionInfo
-               (satisfies? ExceptionInfo e) (assoc :data (ex-data e))))
+    (Throwable->map e)
     ;; Maps might already be error representations
     (map? e) e
     ;; Default serialization for other types
     :else {:message (str e)}))
+
+(defn resolve-fn
+  "Normalize `x` to a function (fn? x) => true.
+
+    - Fn((fn [] ..),:keyword)
+    - Vars(#'clojure.core/str, #'str),
+    - Symbols('clojure.core/str, 'str)
+
+   :clj  supports fn?/Var/Symbol (with requiring-resolve fallback).
+   :cljs only accepts actual functions"
+  [x]
+  #?(:clj
+     (cond
+       (fn? x) x
+       (keyword? x) x
+       (var? x) (let [v @x] (when (fn? v) v))
+       (symbol? x)
+       (let [v (or
+                 ;; already-loaded namespaces
+                 (resolve x)
+                 ;; try to load the ns
+                 (try
+                   (requiring-resolve x)
+                   (catch Throwable _ nil)))]
+         (when (and v (var? v))
+           (let [f @v] (when (fn? f) f))))
+       :else nil)
+     :cljs
+     (cond
+       (fn? x) x
+       (keyword? x) x
+       :else nil)))
+
+(defn resolvable-fn? [x]
+  (boolean (resolve-fn x)))
+
+(def ResolvableFn
+  (malli/deref
+   [:fn
+    {:error/message #?(:clj "Expected a fn, var of fn, symbol resolving to a fn"
+                       :cljs "Expected a fn")}
+    (fn [x]
+      (some? (resolve-fn x)))]))
+
+

--- a/test/unit/commando/impl/utils_test.cljc
+++ b/test/unit/commando/impl/utils_test.cljc
@@ -1,0 +1,54 @@
+(ns commando.impl.utils-test
+  (:require
+   #?(:cljs [cljs.test :refer [deftest is testing]]
+      :clj [clojure.test :refer [deftest is testing]])
+   [clojure.set               :as set]
+   [commando.impl.utils :as sut]
+   [malli.core :as malli]))
+
+
+(deftest throw->map
+  (testing "Serialization exception"
+    (is
+     (=
+       (->
+         (sut/serialize-exception (ex-info "Exception Text" {:value1 "a" :value2 "b"}))
+         (dissoc :via :trace))
+       {:cause "Exception Text", :data {:value1 "a", :value2 "b"}}))))
+
+(deftest resolve-fn
+  #?(:clj
+     (testing "CLJ ResolvableFn"
+       ;; Supported:
+       (is (= true (malli/validate sut/ResolvableFn clojure.core/str)))
+       (is (= true (malli/validate sut/ResolvableFn #'clojure.core/str)))
+       (is (= true (malli/validate sut/ResolvableFn 'clojure.core/str)))
+       (is (= true (malli/validate sut/ResolvableFn #'str)))
+       (is (= true (malli/validate sut/ResolvableFn 'str)))
+       (is (= true (malli/validate sut/ResolvableFn str)))
+       (is (= true (malli/validate sut/ResolvableFn :value)))
+       ;; Unsupported: 
+       (is (= false (malli/validate sut/ResolvableFn "clojure.core/str")))
+       (is (= false (malli/validate sut/ResolvableFn {})))
+       (is (= false (malli/validate sut/ResolvableFn [])))
+       (is (= false (malli/validate sut/ResolvableFn '())))
+       (is (= false (malli/validate sut/ResolvableFn 'UNKOWN)))
+       (is (= false (malli/validate sut/ResolvableFn 'UNKOWN/UNKOWN)))))
+  #?(:cljs
+     (testing "CLJS ResolvableFn"
+       ;; Supported:
+       (is (= true (malli/validate sut/ResolvableFn clojure.core/str)))
+       (is (= true (malli/validate sut/ResolvableFn #'clojure.core/str)))
+       (is (= true (malli/validate sut/ResolvableFn #'str)))
+       (is (= true (malli/validate sut/ResolvableFn str)))
+       (is (= true (malli/validate sut/ResolvableFn :value)))
+       ;; Unsupported:
+       (is (= false (malli/validate sut/ResolvableFn 'str)))
+       (is (= false (malli/validate sut/ResolvableFn 'clojure.core/str)))
+       (is (= false (malli/validate sut/ResolvableFn "clojure.core/str")))
+       (is (= false (malli/validate sut/ResolvableFn {})))
+       (is (= false (malli/validate sut/ResolvableFn [])))
+       (is (= false (malli/validate sut/ResolvableFn '())))
+       (is (= false (malli/validate sut/ResolvableFn 'UNKOWN)))
+       (is (= false (malli/validate sut/ResolvableFn 'UNKOWN/UNKOWN)))
+       )))


### PR DESCRIPTION
- UPDATED :validate-params-fn behavior. At now nil/fales/{}/[] except the 'true' will understand as a failed validation. if the return value is a data - it will be attached to error map.
- UPDATED :validate-params-fn for all commands.
- UPDATED QueryDSL command-spec docs, with small fix with passing QueryExpression in JSON query style.
- ADDED function normalizer for commando/commands/bultin commands.
- FIXED utils/serialize-exception for CLJS. Same behavior for serializing Error object.
- ADDED tests.