### PR TITLE
Rework Command Postprocessors. Introduce driver system. 

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,10 +17,9 @@ REDESIGNED Registry. Registry is now a map-based structure (`{:type spec, ...}`)
 ```clojure
 ;; vector — order = scan priority
 (registry-create [from-spec fn-spec])
-;; map — explicit keys
-(registry-create {:commando/from from-spec, :commando/fn fn-spec})
 ```
-Built registry can be modified with `registry-assoc` / `registry-dissoc` without rebuilding from scratch.
+Built registry can be modified with `registry-add` / `registry-remove` (identification by `:type` key).
+`registry-assoc` / `registry-dissoc` removed. Map input form for `registry-create` removed — only vectors accepted.
 
 RENAMED `create-registry` → `registry-create`. Old name removed.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,17 @@
-# 1.0.6
+# 1.1.0
 
-ADDED `command-context-spec` in `commando.commands.builtin`. A new command type `:commando/context` (string form: `"commando-context"`) that injects external reference data into instructions via closure. Call `(command-context-spec ctx-map)` to create a CommandMapSpec. Resolves with `{:mode :none}` — before all other commands, so `:commando/from` and `:commando/fn` can depend on context results. Supports `:=` transform, `:default` fallback for missing paths, and returns `nil` when path is not found without `:default`. Full malli validation for both keyword and string key forms.
+**BREAKING** REDESIGNED `:=` / `"="` with the new **Driver system** `:=>` / `"=>"`. The old keys are removed. Migration:
+```clojure
+:= :name              → :=> [:get :name],
+:= [:a :b]            → :=> [:get-in [:a :b]],
+:= (fn [result] ...)  → :=> [:fn (fn [result] ...)].
+"=" "name"            → "=>" ["get" "name"],
+```
+
+Built-in drivers: `:identity` (default), `:get`, `:get-in`, `:select-keys`, `:projection`, `:fn`. Supports pipelines (`[[:get :city] :uppercase]`) and custom drivers via `commando.impl.executing/command-driver` multimethod. See [README](./README.md) for details.
+
+
+ADDED `command-context-spec` in `commando.commands.builtin`. A new command type `:commando/context` (string form: `"commando-context"`) that injects external reference data into instructions via closure. Call `(command-context-spec ctx-map)` to create a CommandMapSpec. Resolves with `{:mode :none}` — before all other commands, so `:commando/from` and `:commando/fn` can depend on context results. Supports `:=>` driver transform, `:default` fallback for missing paths, and returns `nil` when path is not found without `:default`. Full malli validation for both keyword and string key forms.
 
 REDESIGNED Registry. Registry is now a map-based structure (`{:type spec, ...}`) instead of a plain vector. `registry-create` accepts both formats:
 ```clojure

--- a/README.md
+++ b/README.md
@@ -15,17 +15,21 @@
 - [Concept](#concept)
 - [Basics](#basics)
   - [Builtin Functionality](#builtin-functionality)
-	- [command-from-spec](#command-from-spec)
-	- [command-fn-spec](#command-fn-spec)
-	- [command-apply-spec](#command-apply-spec)
-	- [command-mutation-spec](#command-mutation-spec)
-	- [command-macro-spec](#command-macro-spec)
-  - [command-context-spec](#command-context-spec)
+    - [command-from-spec](#command-from-spec)
+    - [command-fn-spec](#command-fn-spec)
+    - [command-apply-spec](#command-apply-spec)
+    - [command-mutation-spec](#command-mutation-spec)
+    - [command-macro-spec](#command-macro-spec)
+    - [command-context-spec](#command-context-spec)
+  - [Drivers (Post-Processing)](#drivers-post-processing)
+    - [Built-in Drivers](#built-in-drivers)
+    - [Pipeline](#pipeline)
+    - [Custom Drivers](#custom-drivers)
   - [Adding New Commands](#adding-new-commands)
 - [Status-Map and Internals](#status-map-and-internals)
   - [Configuring Execution Behavior](#configuring-execution-behavior)
-	- [`:debug-result`](#debug-result)
-	- [`:error-data-string`](#error-data-string)
+    - [`:debug-result`](#debug-result)
+    - [`:error-data-string`](#error-data-string)
   - [Performance](#performance)
 - [Integrations](#integrations)
 - [Versioning](#versioning)
@@ -68,8 +72,8 @@ The main idea of Commando is to create your own flexible, data-driven DSL. Comma
 {"user-from-oracle-db" {:oracle/db :query-user :where [:= :session-id "SESSION-FSD123F1N1ASJ12UIVC"]}
  "inserting-info-about-user-in-mysql"
  {:mysql/db :add-some-user-action
-  :insert [{:action "open-app" :user {:commando/from ["user-from-oracle-db"] := :login}}
-		   {:action "query-insurense-data" :user {:commando/from ["user-from-oracle-db"] := :login}}
+  :insert [{:action "open-app" :user {:commando/from ["user-from-oracle-db"] :=> [:get :login]}}
+		   {:action "query-insurense-data" :user {:commando/from ["user-from-oracle-db"] :=> [:get :login]}}
 		   ...]}}
 ```
 
@@ -111,16 +115,16 @@ As Commando is simply a graph-based resolver with easy configuration, it is not 
   ;;   .---- Instruction
   ;;  V
   {"1" 1
-   ;;                        Command -----.
-   ;;                                     |
-   "2" {:commando/from ["1"] := inc} ;; <-'
-   "3" {:commando/from ["2"] := inc}})
+   ;;                                 Command -----.
+   ;;                                              |
+   "2" {:commando/from ["1"] :=> [:fn inc]} ;; <---'
+   "3" {:commando/from ["2"] :=> [:fn inc]}})
 ;; => {:instruction {"1" 1, "2" 2, "3" 3}}
 ```
 
 The above function composes "Instructions", "Commands", and a "CommandRegistry".
 - **Instruction**: a Clojure map, large or small, containing data and _commands_. The instruction describes the data structure and the transformations to apply.
-- **Command**: a data-lexeme that is evaluated and returns a result. The rules for parsing and executing commands are flexible and customizable. Command `:command/from` return value by the absolute or relative path, can optionally apply a function provided under the `:=` key.
+- **Command**: a data-lexeme that is evaluated and returns a result. The rules for parsing and executing commands are flexible and customizable. Command `:commando/from` returns a value by absolute or relative path, with optional post-processing via the `:=>` driver key.
 - **CommandRegistry**: a vector or map of CommandMapSpecs describing data-lexemes that should be treated as _commands_ by the library. When passed as a vector, the order defines the command scan priority. You can also pre-build a registry with `registry-create` and pass it directly.
 
 ### Builtin Functionality
@@ -129,7 +133,7 @@ The basic commands is found in namespace `commando.commands.builtin`. It describ
 
 #### command-from-spec
 
-Retrieves a value from the instruction by path. An optional `":="` key applies a function to the result.
+Retrieves a value from the instruction by path. Use the `:=>` driver key to post-process the result (see [Drivers](#drivers-post-processing)).
 
 **Absolute path** — list of keys from the instruction root:
 
@@ -194,7 +198,7 @@ A convenient wrapper over `apply`.
 
 #### command-apply-spec
 
-A wrapper similar to `commando/fn`, but conceptually closer to `commando/from`, operating on values already passed to the key.
+Returns the value of `:commando/apply` as-is. Use `:=>` driver to post-process the result.
 
 ```clojure
 (commando/execute
@@ -203,10 +207,10 @@ A wrapper similar to `commando/fn`, but conceptually closer to `commando/from`, 
 		{"1" {:commando/apply
 			  {"2" {:commando/apply
 					{"3" {:commando/apply {"4" {:final "5"}}
-						  := #(get % "4")}}
-					:= #(get % "3")}}
-			  := #(get % "2")}}
-		:= #(get % "1")}})
+						  :=> [:get "4"]}}
+					:=> [:get "3"]}}
+			  :=> [:get "2"]}}
+		:=> [:get "1"]}})
 ;; => {"0" {:final "5"}}
 ```
 
@@ -219,10 +223,10 @@ Imagine the following instruction is your initial database migration, adding use
   [commands-builtin/command-from-spec
    commands-builtin/command-mutation-spec]
   {"add-new-user-01" {:commando/mutation :add-user :name "Bob Anderson"
-					  :permissions [{:commando/from ["perm_send_mail"] := :id}
-					  {:commando/from ["perm_recv_mail"] := :id }]}
+					  :permissions [{:commando/from ["perm_send_mail"] :=> [:get :id]}
+					  {:commando/from ["perm_recv_mail"] :=> [:get :id]}]}
    "add-new-user-02" {:commando/mutation :add-user :name "Damian Nowak"
-					  :permissions [{:commando/from ["perm_recv_mail"] := :id}]}
+					  :permissions [{:commando/from ["perm_recv_mail"] :=> [:get :id]}]}
    "perm_recv_mail" {:commando/mutation :add-permission
 					 :name "receive-email-notification"}
    "perm_send_mail" {:commando/mutation :add-permission
@@ -259,7 +263,7 @@ Asume we have a Instruction what calculates mean.
   [commands-builtin/command-from-spec
    commands-builtin/command-apply-spec
    commands-builtin/command-fn-spec]
-  {:= :result
+  {:=> [:get :result]
    :commando/apply
    {:vector-of-numbers [1, 2, 3, 4, 5]
 	:result
@@ -276,7 +280,7 @@ Define a macro
 
 ```clojure
 (defmethod commands-builtin/command-macro :mean-calc [{vector-of-numbers :vector-of-numbers}]
-  {:= :result
+  {:=> [:get :result]
    :commando/apply
    {:vector-of-numbers vector-of-numbers
 	:result
@@ -323,7 +327,7 @@ Injects external reference data (dictionaries, config, feature flags) into instr
    commands-builtin/command-fn-spec]
   {:warrior     {:commando/context [:heroes "warrior"]}
    :fire-bonus  {:commando/context [:buffs :fire-sword]}
-   :hit-damage  {:commando/fn * :args [{:commando/from [:warrior] := :damage}
+   :hit-damage  {:commando/fn * :args [{:commando/from [:warrior] :=> [:get :damage]}
                                         {:commando/from [:fire-bonus]}]}
    :arena-name  {:commando/context [:arenas :default] :default "Colosseum"}})
 ;; => {:warrior {:hp 120 :damage 15}
@@ -332,7 +336,176 @@ Injects external reference data (dictionaries, config, feature flags) into instr
 ;;     :arena-name "Colosseum"}
 ```
 
-Missing path returns `nil`; use `:default` for an explicit fallback. The `:=` key applies a transform to the resolved value, same as in `:commando/from`. String-key form (`"commando-context"`, `"default"`, `"="`) is available for JSON compatibility.
+Missing path returns `nil`; use `:default` for an explicit fallback. Use `:=>` driver for post-processing the resolved value, same as in `:commando/from`. String-key form (`"commando-context"`, `"default"`, `"=>"`) is available for JSON compatibility.
+
+### Drivers (Post-Processing)
+
+Drivers provide a **data-driven** way to post-process command results. After a command's `:apply` function produces a raw result, the driver transforms it before the value is placed back into the instruction.
+
+A driver is declared via the `:=>` key (or `"=>"` for string-key/JSON maps) on any command, using a **vector DSL**:
+
+```clojure
+;; Vector form — [driver-name & params]
+{:commando/.. :=> [:get :name]}
+{:commando/.. :=> [:get-in [:address :city]]}
+{:commando/.. :=> [:select-keys [:name :email]]}
+{:commando/.. :=> [:fn inc]}
+;; Keyword form — driver with no params
+{:commando/.. :=> :my-custom-driver}
+;; Pipeline — first element is a vector, steps are chained left-to-right
+{:commando/.. :=> [[:get :address] [:get-in [:location :city]] :uppercase]}
+```
+
+If no `:=>` is specified, the default driver is `:get-in` with no params, which acts as identity (pass-through).
+
+```clojure
+(commando/execute
+ [commands-builtin/command-from-spec]
+ {:data {:name "John" :age 30 :email "john@example.com" :internal-id 999}
+  :subset {:commando/from [:data]
+           :=> [:select-keys [:name :email]]}})
+;; => {:data {...}, :subset {:name "John", :email "john@example.com"}}
+```
+
+#### Built-in Drivers
+
+**`:identity`** — pass-thought behavior (enabled by default):
+
+```clojure
+{:commando/from [:data] :=> :identity}
+;; {:name "John" :age 30}  => {:name "John" :age 30}
+```
+
+**`:get`** — extract a single key from the result:
+
+```clojure
+{:commando/from [:data] :=> [:get :name]}
+;; {:name "John" :age 30}  =>  "John"
+```
+
+**`:get-in`** — extract a value at a deep path (also the default driver):
+
+```clojure
+{:commando/from [:data] :=> [:get-in [:address :location :city]]}
+;; {:address {:location {:city "Kyiv"}}}  =>  "Kyiv"
+```
+
+**`:select-keys`** — select a subset of keys:
+
+```clojure
+{:commando/from [:data] :=> [:select-keys [:name :email]]}
+;; {:name "John" :age 30 :email "j@e.com"}  =>  {:name "John" :email "j@e.com"}
+```
+
+**`:fn`** — apply an arbitrary function (for cases when you need runtime transforms):
+
+```clojure
+{:commando/from [:data] :=> [:fn inc]}
+{:commando/from [:data] :=> [:fn #(reduce + %)]}
+```
+
+**`:projection`** — rename and reshape fields (pure data, no function transforms):
+
+```clojure
+{:commando/from [:data]
+ :=> [:projection [[:user-id :id]
+                   [:user-name [:profile :full-name]]
+                   [:city [:address :location :city]]]]}
+;; Each field spec: [output-key]
+;;                   [output-key source-key-or-path]
+```
+
+Full projection example:
+
+```clojure
+(commando/execute
+  [commands-builtin/command-from-spec]
+  {:data {:id "u-101"
+          :profile {:full-name "John Doe"}
+          :address {:location {:city "kyiv"} :zip "01001"}
+          :metadata {:labels ["important" "urgent"]}}
+   :result {:commando/from [:data]
+            :=> [:projection [[:user-id :id]
+                              [:user-name [:profile :full-name]]
+                              [:city [:address :location :city]]
+                              [:tags [:metadata :labels]]]]}})
+;; => {:data {...}
+;;     :result {:user-id "u-101"
+;;              :user-name "John Doe"
+;;              :city "kyiv"
+;;              :tags ["important" "urgent"]}}
+```
+
+#### Pipeline
+
+When the first element of `:=>` is itself a vector, the entire value is treated as a **pipeline** — a sequence of driver steps chained left-to-right. Each step's output becomes the next step's input:
+
+```clojure
+(commando/execute
+  [commands-builtin/command-from-spec]
+  {:data {:profile {:name "john doe"} :age 30 :secret "x"}
+   ;; Step 1: get :profile → {:name "john doe"}
+   ;; Step 2: get :name    → "john doe"
+   ;; Step 3: uppercase    → "JOHN DOE"
+   :result {:commando/from [:data]
+            :=> [[:get :profile] [:get :name] :uppercase]}})
+;; => {:data {...}, :result "JOHN DOE"}
+```
+
+Each step in the pipeline can be:
+- A **vector** `[:driver-name & params]` — e.g. `[:get :name]`, `[:get-in [:a :b]]`, `[:fn inc]`
+- A **keyword** `:driver-name` — shorthand for a parameterless driver, e.g. `:uppercase`
+- A **string** `"driver-name"` — for JSON compatibility, keywordized at runtime
+
+Pipeline works with JSON string keys too:
+
+```clojure
+{"data" {"city" "kyiv"}
+ "result" {"commando-from" ["data"] "=>" [["get" "city"] "uppercase"]}}
+```
+
+#### Custom Drivers
+
+Drivers use Clojure's multimethod system. Define a new driver by extending `commando.impl.executing/command-driver`:
+
+```clojure
+(require '[commando.impl.executing :as commando-executing])
+
+(defmethod commando-executing/command-driver :uppercase
+  [_driver-name _driver-params applied-result _command-data _instruction _command-path-obj]
+  (if (string? applied-result)
+    (clojure.string/upper-case applied-result)
+    applied-result))
+
+;; Usage:
+{:commando/from [:data] :=> :uppercase}
+```
+
+The driver function receives six arguments:
+1. `driver-name` — keyword (dispatch value)
+2. `driver-params` — seq of parameters from the `:=>` vector (`nil` for keyword-only drivers)
+3. `applied-result` — the value returned by `:apply`
+4. `command-data` — the original command map before `:apply` ran
+5. `instruction` — the full instruction map
+6. `command-path-obj` — `CommandMapPath` object
+
+#### Drivers and JSON Compatibility
+
+All built-in driver declarations (except `:fn`) are plain data — keywords, strings, and vectors — making them fully serializable to JSON, EDN, or Transit:
+
+```clojure
+;; JSON-compatible instruction with drivers
+{"data" {"name" "John" "age" 30}
+ "name" {"commando-from" ["data"]
+         "=>" ["get" "name"]}}
+
+;; Pipeline in JSON
+{"data" {"address" {"city" "kyiv"}}
+ "result" {"commando-from" ["data"]
+           "=>" [["get-in" ["address" "city"]] "uppercase"]}}
+```
+
+String driver names are automatically keywordized at runtime.
 
 ### Adding new commands
 
@@ -344,11 +517,11 @@ Here's an example of another instruction, utilizing step-by-step extraction of k
 (commando/execute
   [commands-builtin/command-from-spec]
   {"1" {:values {:a 1 :b -1}}
-   "a-value" {:commando/from ["1" :values :a] := (partial * 100)}
-   "b-value" {:commando/from ["1" :values :b] := (partial * -100)}
+   "a-value" {:commando/from ["1" :values :a] :=> [:fn (partial * 100)]}
+   "b-value" {:commando/from ["1" :values :b] :=> [:fn (partial * -100)]}
    "args" {:a {:commando/from ["a-value"]}
 		   :b {:commando/from ["b-value"]}}
-   "summ=" {:commando/from ["args"] := (fn [{:keys [a b]}] (+ a b))}})
+   "summ=" {:commando/from ["args"] :=> [:fn (fn [{:keys [a b]}] (+ a b))]}})
 ;; =>
 ;; {"1" {:values {:a 1, :b -1}},
 ;;  "a-value" 100,
@@ -357,7 +530,7 @@ Here's an example of another instruction, utilizing step-by-step extraction of k
 ;;  "summ=" 200}
 ```
 
-The main challenge with the above instruction is that everything is processed via the optional `:=` key in the `:commando/from` command. This may be improved by introducing custom command types.
+The main challenge with the above instruction is that everything is processed via the `:=> [:fn ...]` driver. This may be improved by introducing custom command types.
 
 Let's create a new command using a CommandMapSpec configuration map:
 
@@ -416,8 +589,8 @@ Now you can use it for more expressive operations like "summ=" and "multiply=" a
 (commando/execute
   command-registry
   {"1" {:values {:a 1 :b -1}}
-   "a-value" {:commando/from ["1" :values :a] := (partial * 100)}
-   "b-value" {:commando/from ["1" :values :b] := (partial * -100)}
+   "a-value" {:commando/from ["1" :values :a] :=> [:fn (partial * 100)]}
+   "b-value" {:commando/from ["1" :values :b] :=> [:fn (partial * -100)]}
    "summ=" {:CALC= +
 			:ARGS [{:commando/from ["a-value"]}
 				   {:commando/from ["b-value"]}

--- a/README.md
+++ b/README.md
@@ -125,7 +125,7 @@ As Commando is simply a graph-based resolver with easy configuration, it is not 
 The above function composes "Instructions", "Commands", and a "CommandRegistry".
 - **Instruction**: a Clojure map, large or small, containing data and _commands_. The instruction describes the data structure and the transformations to apply.
 - **Command**: a data-lexeme that is evaluated and returns a result. The rules for parsing and executing commands are flexible and customizable. Command `:commando/from` returns a value by absolute or relative path, with optional post-processing via the `:=>` driver key.
-- **CommandRegistry**: a vector or map of CommandMapSpecs describing data-lexemes that should be treated as _commands_ by the library. When passed as a vector, the order defines the command scan priority. You can also pre-build a registry with `registry-create` and pass it directly.
+- **CommandRegistry**: a vector of CommandMapSpecs describing data-lexemes that should be treated as _commands_ by the library. The order defines the command scan priority. You can also pre-build a registry with `registry-create` and pass it directly. Use `registry-add` / `registry-remove` to modify a built registry.
 
 ### Builtin Functionality
 
@@ -558,7 +558,7 @@ Let's create a new command using a CommandMapSpec configuration map:
 Now you can use it for more expressive operations like "summ=" and "multiply=" as shown below:
 
 ```clojure
-;; Vector form — order defines scan priority
+;; Build a registry — vector order defines scan priority
 (def command-registry
   (commando/registry-create
 	[commands-builtin/command-from-spec
@@ -572,19 +572,16 @@ Now you can use it for more expressive operations like "summ=" and "multiply=" a
 				(apply (:CALC= m) (:ARGS m)))
 	  :dependencies {:mode :all-inside}}]))
 
-;; Map form — explicit type keys
-(def command-registry
-  (commando/registry-create
-	{:commando/from commands-builtin/command-from-spec
-	 :CALC=        {:type :CALC=
-	                :recognize-fn #(and (map? %) (contains? % :CALC=))
-	                :validate-params-fn (fn [m]
-	                                      (and
-	                                        (fn? (:CALC= m))
-	                                        (not-empty (:ARGS m))))
-	                :apply (fn [_instruction _command m]
-	                          (apply (:CALC= m) (:ARGS m)))
-	                :dependencies {:mode :all-inside}}}))
+;; Modify a built registry
+(def extended-registry
+  (commando/registry-add command-registry
+    {:type :NEW-CMD
+     :recognize-fn #(and (map? %) (contains? % :NEW-CMD))
+     :apply (fn [_ _ m] (:NEW-CMD m))
+     :dependencies {:mode :none}}))
+
+(def shrunk-registry
+  (commando/registry-remove extended-registry :NEW-CMD))
 
 (commando/execute
   command-registry

--- a/README.md
+++ b/README.md
@@ -369,7 +369,7 @@ If no `:=>` is specified, the default driver is `:get-in` with no params, which 
 
 #### Built-in Drivers
 
-**`:identity`** — pass-thought behavior (enabled by default):
+**`:identity`** — pass-through behavior (enabled by default):
 
 ```clojure
 {:commando/from [:data] :=> :identity}

--- a/src/commando/commands/builtin.cljc
+++ b/src/commando/commands/builtin.cljc
@@ -60,15 +60,15 @@
 
 (def ^{:doc "
   Description
-    command-apply-spec - Apply `:=` function/symbol/keyword
-    to value passed inside `:commando/apply`
+    command-apply-spec - Returns value of `:commando/apply`.
+    Use `:=>` driver to post-process the result.
 
   Example
     (:instruction
       (commando/execute
         [command-apply-spec]
         {:commando/apply {:value 10}
-         := :value}))
+         :=> [:get :value]}))
      ;; => 10
 
    See Also
@@ -80,15 +80,11 @@
    :validate-params-fn (fn [m]
                          (if-let [m-explain
                                   (malli-error/humanize
-                                    (malli/explain
-                                      [:map [:commando/apply :any]
-                                       [:= utils/ResolvableFn]] m))]
+                                    (malli/explain [:map [:commando/apply :any]] m))]
                            m-explain
                            true))
    :apply (fn [_instruction _command-path-obj command-map]
-            (let [result (:commando/apply command-map)
-                  result (let [m-= (utils/resolve-fn (:= command-map))] (if m-= (m-= result) result))]
-              result))
+            (:commando/apply command-map))
    :dependencies {:mode :all-inside}})
 
 ;; ======================
@@ -121,7 +117,7 @@
          {:commando/fn (fn [& values] (apply + values))
           :args [1 2 3]}
          \"value-incremented\"
-         {:commando/from [\"value\"] := inc}}))
+         {:commando/from [\"value\"] :=> [:fn inc]}}))
       => {\"value\" 6, \"value-incremented\" 7}
 
     (:instruction
@@ -135,12 +131,12 @@
     (:instruction
      (commando/execute [command-from-spec]
        {\"a\" {\"value\" {\"container\" 1}
-            \"result\" {\"commando-from\" [\"../\" \"value\"] \"=\" \"container\"}}
+            \"result\" {\"commando-from\" [\"../\" \"value\"] \"=>\" [\"get\" \"container\"]}}
         \"b\" {\"value\" {\"container\" 2}
-            \"result\" {\"commando-from\" [\"../\" \"value\"] \"=\" \"container\"}}}))
+            \"result\" {\"commando-from\" [\"../\" \"value\"] \"=>\" [\"get\" \"container\"]}}}))
 
       => /{\"a\" {\"value\" {\"container\" 1}, \"result\" 1},
-         / \"b\" {\"value\" {\"container\" 2}, \"result\" 2}} 
+         / \"b\" {\"value\" {\"container\" 2}, \"result\" 2}}
 
    See Also
      `commando.core/execute`
@@ -162,40 +158,19 @@
                                  (contains? m :commando/from)
                                  (malli-error/humanize
                                    (malli/explain
-                                     [:map
-                                      [:commando/from -malli:commando-from-path]
-                                      [:= {:optional true} [:or utils/ResolvableFn :string]]]
+                                     [:map [:commando/from -malli:commando-from-path]]
                                      m))
                                  (contains? m "commando-from")
                                  (malli-error/humanize
                                    (malli/explain
-                                     [:map
-                                      ["commando-from" -malli:commando-from-path]
-                                      ["=" {:optional true} [:string {:min 1}]]]
+                                     [:map ["commando-from" -malli:commando-from-path]]
                                      m)))]
                            (if m-explain
                              m-explain
                              true)))
-   :apply (fn [instruction command-path-obj command-map]
-            (cond
-              (contains? command-map :commando/from)
-              (let [path-to-another-command (deps/point-target-path instruction command-path-obj)
-                    result (get-in instruction path-to-another-command)
-                    result (let [m-= (:= command-map)]
-                             (if m-= (if (string? m-=)
-                                       (get result m-=)
-                                       (let [m-= (utils/resolve-fn m-=)]
-                                         (m-= result))) result))]
-                result)
-              (contains? command-map "commando-from")
-              (let [path-to-another-command (deps/point-target-path instruction command-path-obj)
-                    result (get-in instruction path-to-another-command)
-                    result (if-let [m-= (get command-map "=")]
-                             (if (string? m-=)
-                               (get result m-=)
-                               result)
-                             result)]
-                result)))
+   :apply (fn [instruction command-path-obj _command-map]
+            (let [path-to-another-command (deps/point-target-path instruction command-path-obj)]
+              (get-in instruction path-to-another-command)))
    :dependencies {:mode :point
                   :point-key [:commando/from
                               "commando-from"]}})
@@ -213,17 +188,17 @@
 
    Instruction usage (keyword keys):
      {:commando/context [:path :to :data]}
-     {:commando/context [:path :to :data] := :key}
+     {:commando/context [:path :to :data] :=> [:get :key]}
      {:commando/context [:path :to :data] :default 0}
 
    Instruction usage (string keys, JSON-compatible):
      {\"commando-context\" [\"path\" \"to\" \"data\"]}
-     {\"commando-context\" [\"path\" \"to\" \"data\"] \"=\" \"key\"}
+     {\"commando-context\" [\"path\" \"to\" \"data\"] \"=>\" [\"get\" \"key\"]}
      {\"commando-context\" [\"path\" \"to\" \"data\"] \"default\" 0}
 
    Parameters:
      :commando/context — sequential path for get-in on ctx
-     := — optional transform function/keyword applied to the resolved value
+     :=> — optional driver for post-processing [:get :key], [:fn inc], etc.
      :default — optional fallback value when path is not found in ctx.
                  Without :default, missing path throws an error.
 
@@ -263,7 +238,6 @@
                    [:map
                     [kw-key [:sequential {:error/message "commando/context should be a sequential path: [:some :key]"}
                              [:or :string :keyword :int]]]
-                    [:= {:optional true} [:or utils/ResolvableFn :string]]
                     [:default {:optional true} :any]]
                    m))
                (contains? m str-key)
@@ -272,34 +246,21 @@
                    [:map
                     [str-key [:sequential {:error/message "commando-context should be a sequential path: [\"some\" \"key\"]"}
                               [:or :string :keyword :int]]]
-                    ["=" {:optional true} [:string {:min 1}]]
                     ["default" {:optional true} :any]]
                    m)))]
          (if m-explain m-explain true)))
      :apply
      (fn [_instruction _command-path-obj command-map]
-       (let [[path m-= m-default has-default?]
-             (cond
-               (contains? command-map kw-key)
-               [(get command-map kw-key)
-                (:= command-map)
-                (:default command-map)
-                (contains? command-map :default)]
-               (contains? command-map str-key)
-               [(get command-map str-key)
-                (get command-map "=")
-                (get command-map "default")
-                (or (contains? command-map "default")
-                    (contains? command-map :default))])
+       (let [path (or (get command-map kw-key) (get command-map str-key))
+             has-default? (or (contains? command-map :default)
+                              (contains? command-map "default"))
+             m-default (if (contains? command-map :default)
+                         (:default command-map)
+                         (get command-map "default"))
              result (get-in ctx path ::not-found)]
          (if (= result ::not-found)
            (if has-default? m-default nil)
-           (if m-=
-             (if (string? m-=)
-               (get result m-=)
-               (let [resolved (utils/resolve-fn m-=)]
-                 (resolved result)))
-             result))))
+           result)))
      :dependencies {:mode :none}}))
 
 ;; ======================

--- a/src/commando/core.cljc
+++ b/src/commando/core.cljc
@@ -12,10 +12,9 @@
 ;; -- Registry API --
 
 (defn registry-create
-  "Creates a 'Command' registry from a map or vector of CommandMapSpecs.
+  "Creates a 'Command' registry from a vector of CommandMapSpecs.
 
    Accepts either:
-   - A map of {type -> CommandMapSpec}
    - A vector of CommandMapSpecs (order defines command scan priority)
    - An already-built registry (returned as-is)
 
@@ -44,47 +43,38 @@
 
    The function returns a built registry that can be used to resolve Instruction
 
-  Example (map)
-   (registry-create
-     {:commando/from commando.commands.builtin/command-from-spec
-      :commando/fn   commando.commands.builtin/command-fn-spec})
-
-  Example (vector — order defines scan priority)
+  Example:
    (registry-create
      [commando.commands.builtin/command-from-spec
       commando.commands.builtin/command-fn-spec])"
-  ([registry]
-   (registry-create registry nil))
-  ([registry opts]
-   (cond
-     (registry/built? registry) registry
-     (vector? registry) (let [specs-map (into {} (map (juxt :type identity)) registry)
-                              order     (mapv :type registry)]
-                          (registry/build specs-map (merge opts {:registry-order order})))
-     (map? registry) (registry/build registry opts)
-     :else (throw (ex-info "Registry must be a map, vector, or a built registry"
-                           {:registry registry})))))
+  [registry]
+  (cond
+    (registry/built? registry) registry
+    (vector? registry) (registry/build registry)
+    :else (throw (ex-info "Registry must be a vector or a built registry"
+                         {:registry registry}))))
 
-(defn registry-assoc
+(defn registry-add
   "Adds or replaces a CommandMapSpec in a built registry.
-   The spec is keyed by `command-map-spec-type` and appended to the scan order
-   if not already present. Revalidates the registry.
+   Identification is by the spec's :type key. If a spec with the same :type
+   already exists it is replaced; otherwise the new spec is appended.
+   Revalidates the registry.
 
    Example:
-     (-> (registry-create {...})
-         (registry-assoc :my/cmd my-cmd-spec))"
-  [built-registry command-map-spec-type command-map-spec]
-  (registry/registry-assoc built-registry command-map-spec-type command-map-spec))
+     (-> (registry-create [...])
+         (registry-add my-cmd-spec))"
+  [built-registry command-map-spec]
+  (registry/registry-add built-registry command-map-spec))
 
-(defn registry-dissoc
-  "Removes a CommandMapSpec from a built registry by its type key.
-   Updates the scan order accordingly. Revalidates the registry.
+(defn registry-remove
+  "Removes a CommandMapSpec from a built registry by its :type.
+   Revalidates the registry.
 
    Example:
-     (-> (registry-create {...})
-         (registry-dissoc :my/cmd))"
+     (-> (registry-create [...])
+         (registry-remove :my/cmd))"
   [built-registry command-map-spec-type]
-  (registry/registry-dissoc built-registry command-map-spec-type))
+  (registry/registry-remove built-registry command-map-spec-type))
 
 ;; -- Core Steps --
 
@@ -168,7 +158,7 @@
 
 (defn execute
   [registry instruction]
-  {:pre [(or (map? registry) (vector? registry))]}
+  {:pre [(or (vector? registry) (registry/built? registry))]}
   (binding [utils/*execute-internals* (utils/-execute-internals-push (str (random-uuid)))]
     (let [start-time (utils/now)]
       (-> (smap/status-map-pure {:instruction instruction})

--- a/src/commando/core.cljc
+++ b/src/commando/core.cljc
@@ -6,7 +6,8 @@
    [commando.impl.graph            :as graph]
    [commando.impl.registry         :as registry]
    [commando.impl.status-map       :as smap]
-   [commando.impl.utils            :as utils]))
+   [commando.impl.utils            :as utils]
+   [commando.driver.builtin]))
 
 ;; -- Registry API --
 

--- a/src/commando/driver/builtin.cljc
+++ b/src/commando/driver/builtin.cljc
@@ -1,0 +1,122 @@
+(ns commando.driver.builtin
+  "Built-in drivers for Commando post-processing.
+   Extend `commando.impl.executing/command-driver` multimethod.
+
+   Vector DSL:
+     :=> :keyword              — driver without params
+     :=> [:driver-name params] — driver with params
+
+   Pipeline (first element is a vector):
+     :=> [[:get :address] [:get-in [:location :city]] :uppercase]
+
+   Examples:
+     :=> [:get :name]
+     :=> [:get-in [:address :city]]
+     :=> [:select-keys [:name :email]]
+     :=> [:projection [[:user-id :id] [:city [:address :city]]]]
+     :=> [:fn inc]
+     :=> :uppercase
+     :=> [[:get-in [:profile :name]] :uppercase]"
+  (:require
+   [commando.impl.executing :as executing]
+   [commando.impl.utils :as commando-utils]))
+
+;; -- identity --
+
+(defmethod executing/command-driver :identity
+  [_ _driver-params applied-result _command-data _instruction _command-path-obj]
+  ;; => [:identity] pass-through
+  applied-result)
+
+;; -- :get-in --
+
+(defmethod executing/command-driver :get-in
+  [_ driver-params applied-result _command-data _instruction _command-path-obj]
+  ;; :=> [:get-in [:address :city]]
+  ;; No params = identity pass-through (default behavior).
+  (let [path (first driver-params)]
+    (if (seq path)
+      (get-in applied-result path)
+      applied-result)))
+
+;; -- :get --
+
+(defmethod executing/command-driver :get
+  [_ driver-params applied-result _command-data _instruction _command-path-obj]
+  ;; :=> [:get :name]
+  ;; No params = identity pass-through (default behavior).
+  (if-let [k (first driver-params)]
+    (get applied-result k)
+    applied-result))
+
+;; -- :select-keys --
+
+(defmethod executing/command-driver :select-keys
+  [_ driver-params applied-result _command-data _instruction _command-path-obj]
+  ;; :=> [:select-keys [:name :email]]
+  (let [ks (first driver-params)]
+    (select-keys applied-result ks)))
+
+;; -- :fn --
+
+(defmethod executing/command-driver :fn
+  [_ driver-params applied-result _command-data _instruction _command-path-obj]
+  ;; :=> [:fn inc]
+  ;; :=> [:fn :keyword]
+  (let [f (commando-utils/resolve-fn (first driver-params))]
+    (if f (f applied-result) applied-result)))
+
+;; -- :projection --
+
+(defmethod executing/command-driver :projection
+  [_ driver-params applied-result _command-data _instruction _command-path-obj]
+  ;; :=> [:projection [[:user-id :id]
+  ;;                   [:user-name [:profile :full-name]]
+  ;;                   [:city [:address :location :city]]]]
+  ;;
+  ;; Field spec:
+  ;;   [output-key]                — (get result output-key)
+  ;;   [output-key source]         — source: keyword, string, or vector path
+  (let [fields (first driver-params)]
+    (if (empty? fields)
+      applied-result
+      (into {}
+        (map
+          (fn [[output-key source]]
+            (let [value (if (nil? source)
+                          (get applied-result output-key)
+                          (if (vector? source)
+                            (get-in applied-result source)
+                            (get applied-result source)))]
+              [output-key value]))
+          fields)))))
+
+;; -- :pipe (pipeline) --
+
+(defn- resolve-pipe-step
+  "Parses a single pipeline step into [driver-name driver-params].
+   Step forms:
+     :keyword           -> [:keyword nil]
+     \"string\"         -> [:keyword nil]
+     [:get :name]       -> [:get (:name)]
+     [\"get\" \"name\"] -> [:get (\"name\")]"
+  [step]
+  (cond
+    (keyword? step) [step nil]
+    (string? step)  [(keyword step) nil]
+    (vector? step)  (let [drv (first step)]
+                      [(if (string? drv) (keyword drv) drv)
+                       (rest step)])))
+
+(defmethod executing/command-driver :pipe
+  [_ driver-params applied-result command-data instruction command-path-obj]
+  ;; :=> [[:get :address] [:get-in [:location :city]] :uppercase]
+  ;; driver-params IS the raw vector of steps (resolve-command-driver passes it as-is)
+  (reduce
+    (fn [result step]
+      (let [[drv-name drv-params] (resolve-pipe-step step)]
+        (executing/command-driver
+          drv-name drv-params result
+          command-data instruction command-path-obj)))
+    applied-result
+    driver-params))

--- a/src/commando/impl/command_map.cljc
+++ b/src/commando/impl/command_map.cljc
@@ -84,8 +84,7 @@
   (malli/schema [:map
                  [:type :keyword]
                  [:recognize-fn fn?]
-                 [:validate-params-fn {:optional true}
-                  fn?]
+                 [:validate-params-fn {:optional true} fn?]
                  [:apply fn?]
                  [:dependencies
                   [:merge

--- a/src/commando/impl/executing.cljc
+++ b/src/commando/impl/executing.cljc
@@ -2,21 +2,70 @@
   (:require
    [commando.impl.command-map :as cm]))
 
+;; ====================
+;; Driver Multimethod
+;; ====================
+
+(defn ^:private resolve-command-driver
+  "Parses :=> value into [driver-keyword driver-params].
+   Accepts:
+     :keyword                   -> [:keyword nil]
+     \"string\"                 -> [:keyword nil]
+     [:get :name]               -> [:get (:name)]
+     [:get-in [:address :city]] -> [:get-in ([:address :city])]
+     [\"get\" \"name\"]         -> [:get (\"name\")]
+
+   Pipeline (first element is vector):
+     [[:get :name] :uppercase]  -> [:pipe raw]
+
+   Priority: :=> in command-data > :default (:get-in)."
+  [command-data _command-spec]
+  (let [raw (or (get command-data :=>) (get command-data "=>"))]
+    (cond
+      (nil? raw)     [:identity nil]
+      (keyword? raw) [raw nil]
+      (string? raw)  [(keyword raw) nil]
+      (vector? raw)  (let [drv (first raw)]
+                       (if (or (vector? drv) (sequential? drv))
+                         [:pipe raw]
+                         [(if (string? drv) (keyword drv) drv)
+                          (rest raw)]))
+      :else          [:identity nil])))
+
+(defmulti command-driver
+  "Post-processing driver for command results.
+   Dispatched on driver-name keyword (first argument).
+
+   Arguments:
+     driver-name      - keyword, dispatch value
+     driver-params    - seq of params from :=> vector (nil when no params)
+     applied-result   - value returned by :apply
+     command-data     - original command map (before :apply ran)
+     instruction      - full instruction map
+     command-path-obj - CommandMapPath object"
+  (fn [driver-name _driver-params _applied-result _command-data _instruction _command-path-obj]
+    driver-name))
+
+;; ====================
+;; Execution Engine
+;; ====================
+
 (defn ^:private execute-single-command
   "Execute a single command and update the instruction at the given path.
+   After :apply produces a raw result, the driver post-processes it.
    Returns updated instruction. Throws on execution failure."
   [instruction command-path-obj]
-  (let [command-spec (cm/command-data command-path-obj)
-        apply-fn (:apply command-spec)
-        command-path (cm/command-path command-path-obj)]
-    (if (empty? command-path)
-      ;; For those case while whole Instruction is only One command
-      ;; then the Command by the [] path should be replaced after apply-fn
-      (let [result (apply-fn instruction command-path-obj instruction)]
-        result)
-      (let [current-value (get-in instruction command-path)
-            result (apply-fn instruction command-path-obj current-value)]
-        (assoc-in instruction command-path result)))))
+  (let [command-spec          (cm/command-data command-path-obj)
+        apply-fn              (:apply command-spec)
+        command-path          (cm/command-path command-path-obj)
+        root?                 (empty? command-path)
+        command-data          (if root? instruction (get-in instruction command-path))
+        applied-result        (apply-fn instruction command-path-obj (dissoc command-data :=> "=>"))
+        [drv-name drv-params] (resolve-command-driver command-data command-spec)
+        result                (command-driver
+                                drv-name drv-params applied-result
+                                command-data instruction command-path-obj)]
+    (if root? result (assoc-in instruction command-path result))))
 
 (defn execute-commands
   "Execute commands in order, stopping on first failure.
@@ -37,4 +86,3 @@
         (if (:error execution-result)
           [current-instruction (:error execution-result)]
           (recur execution-result (rest remaining-commands)))))))
-

--- a/src/commando/impl/registry.cljc
+++ b/src/commando/impl/registry.cljc
@@ -1,44 +1,48 @@
 (ns commando.impl.registry
   "API for registry.
 
-   A registry is a map-based collection of command specifications that define how to
+   A registry is a vector-based collection of command specifications that define how to
    recognize, validate, and execute commands found in instruction map.
+   Vector order defines the command scan priority.
 
    Input (user-facing):
      (registry/build
-       {:commando/fn   cmds/command-fn-spec
-        :commando/from cmds/command-from-spec}
-       {:registry-order [:commando/from :commando/fn]})
+       [cmds/command-from-spec cmds/command-fn-spec])
 
    Output (built registry):
-     {:registry           {:commando/fn spec1, :commando/from spec2}
-      :registry-order     [:commando/from :commando/fn]
+     {:registry           [command-from-spec command-fn-spec]
       :registry-validated 1709654400000
       :registry-hash      12345}"
   (:require
    [commando.impl.command-map :as cm]))
 
 (defn- validate-registry
-  "Validates all specs in the registry map.
+  "Validates all specs in the registry vector.
    Returns {:valid? true} or {:valid? false :errors [...]}"
-  [specs-map]
-  (let [empty-errors (when (empty? specs-map)
+  [specs-vec]
+  (let [empty-errors (when (empty? specs-vec)
                        [{:type :empty-command-specs
                          :message "Registry is empty"}])
-        validation-errors (reduce-kv
-                            (fn [errors type spec]
+        validation-errors (reduce
+                            (fn [errors spec]
                               (if-let [error (:error (cm/validate-command-spec spec))]
                                 (conj errors {:type :invalid-spec
-                                              :command-map-spec/type type
+                                              :command-map-spec/type (:type spec)
                                               :message error})
-                                (if (not= type (:type spec))
-                                  (conj errors {:type :type-mismatch
-                                                :command-map-spec/type type
-                                                :message (str "Registry key " type " does not match spec :type " (:type spec))})
-                                  errors)))
+                                errors))
                             []
-                            specs-map)
-        all-errors (concat validation-errors empty-errors)]
+                            specs-vec)
+        type-freq (frequencies (map :type specs-vec))
+        dup-errors (reduce-kv
+                     (fn [errs t cnt]
+                       (if (> cnt 1)
+                         (conj errs {:type :duplicate-type
+                                     :command-map-spec/type t
+                                     :message (str "Duplicate type " t " in registry")})
+                         errs))
+                     []
+                     type-freq)
+        all-errors (concat validation-errors empty-errors dup-errors)]
     (if (empty? all-errors)
       {:valid? true}
       {:valid? false :errors (vec all-errors)})))
@@ -64,14 +68,6 @@
    default-command-map-spec
    default-command-value-spec])
 
-(defn- compute-registry-order
-  "Computes the scan order: ordered keys first, then remaining keys in arbitrary order."
-  [specs-map ordered-keys]
-  (let [spec-keys (set (keys specs-map))
-        valid-ordered (filterv spec-keys ordered-keys)
-        remaining (remove (set valid-ordered) (keys specs-map))]
-    (into valid-ordered remaining)))
-
 (defn built?
   "Returns true if the given value is a properly built registry map."
   [registry]
@@ -79,40 +75,33 @@
     (map? registry)
     (some? (:registry-validated registry))
     (some? (:registry-hash registry))
-    (contains? registry :registry)
-    (contains? registry :registry-order)))
+    (vector? (:registry registry))))
 
 (defn build
-  "Builds a command registry from a map of {type -> spec}.
+  "Builds a command registry from a vector of CommandMapSpecs.
 
    Args:
-     specs-map - A map of {:type spec, ...}
-     opts      - Optional map with :registry-order [...] for scan ordering
+     specs-vec - A vector of CommandMapSpec maps, each with at least :type
 
    Returns:
-     A validated registry map or throws an error"
-  ([specs-map] (build specs-map nil))
-  ([specs-map opts]
-   (let [validation (validate-registry specs-map)]
-     (if (:valid? validation)
-       (let [ordered-keys (compute-registry-order specs-map (:registry-order opts))]
-         {:registry           specs-map
-          :registry-order     ordered-keys
-          :registry-validated #?(:clj (System/currentTimeMillis)
-                                 :cljs (.now js/Date))
-          :registry-hash      (hash specs-map)})
-       (throw
-         (ex-info "Invalid registry specification"
-           {:errors (:errors validation)
-            :registry specs-map}))))))
+     A validated registry map with :registry vector, or throws an error"
+  [specs-vec]
+  (let [validation (validate-registry specs-vec)]
+    (if (:valid? validation)
+      {:registry           specs-vec
+       :registry-validated #?(:clj (System/currentTimeMillis)
+                              :cljs (.now js/Date))
+       :registry-hash      (hash specs-vec)}
+      (throw
+        (ex-info "Invalid registry specification"
+          {:errors (:errors validation)
+           :registry specs-vec})))))
 
 (defn enrich-runtime-registry [built-registry]
-  (let [registry        (:registry built-registry)
-        registry-order  (:registry-order built-registry)]
-    (assoc built-registry
-      :registry-runtime
-      (into (mapv registry registry-order)
-        internal-command-specs))))
+  (assoc built-registry
+    :registry-runtime
+    (into (vec (:registry built-registry))
+      internal-command-specs)))
 
 (defn reset-runtime-registry [enriched-registry]
   (dissoc enriched-registry :registry-runtime))
@@ -129,21 +118,21 @@
 ;; Registry Helpers
 ;; ----------------
 
-(defn registry-assoc
-  "Adds or replaces a spec in a built registry. Revalidates."
-  [built-registry command-map-spec-type command-map-spec]
-  (let [new-specs (assoc (:registry built-registry) command-map-spec-type command-map-spec)
-        old-order (:registry-order built-registry)
-        new-order (if (some #(= % command-map-spec-type) old-order)
-                    old-order
-                    (conj old-order command-map-spec-type))]
-    (build new-specs {:registry-order new-order})))
+(defn registry-add
+  "Adds or replaces a spec in a built registry (identified by :type). Revalidates."
+  [built-registry command-map-spec]
+  (let [specs-vec (:registry built-registry)
+        spec-type (:type command-map-spec)
+        existing-idx (first (keep-indexed (fn [i s] (when (= (:type s) spec-type) i)) specs-vec))
+        new-vec (if existing-idx
+                  (assoc specs-vec existing-idx command-map-spec)
+                  (conj specs-vec command-map-spec))]
+    (build new-vec)))
 
-(defn registry-dissoc
-  "Removes a spec from a built registry. Revalidates."
+(defn registry-remove
+  "Removes a spec from a built registry by its :type. Revalidates."
   [built-registry command-map-spec-type]
-  (let [new-specs (dissoc (:registry built-registry) command-map-spec-type)
-        new-order (filterv #(not= % command-map-spec-type) (:registry-order built-registry))]
-    (build new-specs {:registry-order new-order})))
+  (let [new-vec (filterv #(not= (:type %) command-map-spec-type) (:registry built-registry))]
+    (build new-vec)))
 
 

--- a/src/commando/impl/utils.cljc
+++ b/src/commando/impl/utils.cljc
@@ -98,7 +98,7 @@
    See
      `commando.core/execute`
      `commando.core/execute-commands!`(binding)"
-  [] (or *command-map-spec-registry* {}))
+  [] (or *command-map-spec-registry* []))
 
 ;; ------------------
 ;; Function Resolvers

--- a/test/perf/commando/core_perf_test.clj
+++ b/test/perf/commando/core_perf_test.clj
@@ -101,25 +101,25 @@
          {:sales-totals {:commando/from [:calculations :employee-sales-totals]}
           :employees {:commando/from [:employees]}
           :rates {:commando/from [:config :commission-rates]}}
-         := (fn [{:keys [sales-totals employees rates]}]
+         :=> [:fn (fn [{:keys [sales-totals employees rates]}]
               (into {}
                 (map (fn [[emp-id total-sales]]
                        (let [employee (get employees emp-id)
                              rate-key (:level employee)
                              commission-rate (get rates rate-key 0)]
                          [emp-id (* total-sales commission-rate)]))
-                  sales-totals)))}
+                  sales-totals)))]}
 
         :employee-bonuses
         {:commando/apply
          {:sales-totals {:commando/from [:calculations :employee-sales-totals]}
           :threshold {:commando/from [:config :bonus-threshold]}
           :bonus-amount {:commando/from [:config :performance-bonus]}}
-         := (fn [{:keys [sales-totals threshold bonus-amount]}]
+         :=> [:fn (fn [{:keys [sales-totals threshold bonus-amount]}]
               (into {}
                 (map (fn [[emp-id total-sales]]
                        [emp-id (if (> total-sales threshold) bonus-amount 0)])
-                  sales-totals)))}
+                  sales-totals)))]}
 
         :employee-total-compensation
         {:commando/fn (fn [commissions bonuses]
@@ -133,7 +133,7 @@
           :sales-totals {:commando/from [:calculations :employee-sales-totals]}
           :compensations {:commando/from [:calculations :employee-total-compensation]}
           :op-costs {:commando/from [:config :department-op-cost]}}
-         := (fn [{:keys [employees sales-totals compensations op-costs]}]
+         :=> [:fn (fn [{:keys [employees sales-totals compensations op-costs]}]
               (let [initial-agg {:sales {:total-revenue 0 :total-compensation 0}
                                  :marketing {:total-revenue 0 :total-compensation 0}
                                  :engineering {:total-revenue 0 :total-compensation 0}}]
@@ -154,7 +154,7 @@
                           :operating-cost op-cost
                           :net-profit profit)))
                     data
-                    op-costs))))}}
+                    op-costs))))]}}
 
        :final-report
        {:commando/apply
@@ -162,7 +162,7 @@
          :total-sales-per-employee {:commando/from [:calculations :employee-sales-totals]}
          :total-compensation-per-employee {:commando/from [:calculations :employee-total-compensation]}
          :tax-rate {:commando/from [:config :tax-rate]}}
-        := (fn [{:keys [dept-financials total-sales-per-employee total-compensation-per-employee tax-rate]}]
+        :=> [:fn (fn [{:keys [dept-financials total-sales-per-employee total-compensation-per-employee tax-rate]}]
              (let [company-total-revenue (reduce + (map :total-revenue (vals dept-financials)))
                    company-total-compensation (reduce + (map :total-compensation (vals dept-financials)))
                    company-total-op-cost (reduce + (map :operating-cost (vals dept-financials)))
@@ -180,7 +180,7 @@
                 :department-breakdown dept-financials
                 :employee-performance
                 {:top-earner (key (apply max-key val total-compensation-per-employee))
-                 :top-seller (key (apply max-key val total-sales-per-employee))}}))}})))
+                 :top-seller (key (apply max-key val total-sales-per-employee))}}))]}}))
 
 
 ;; ==============================

--- a/test/unit/commando/commands/builtin_test.cljc
+++ b/test/unit/commando/commands/builtin_test.cljc
@@ -17,8 +17,8 @@
     (is (=
           {:vec1 [1 2 3], :vec2 [3 2 1], :result-simple 10, :result-with-deps 10}
           (:instruction
-            (commando/execute {:commando/fn command-builtin/command-fn-spec
-                               :commando/from command-builtin/command-from-spec}
+            (commando/execute [command-builtin/command-fn-spec
+                               command-builtin/command-from-spec]
               {:vec1 [1 2 3]
                :vec2 [3 2 1]
                :result-simple {:commando/fn (fn [& [v1 v2]] (reduce + (map * v1 v2)))
@@ -34,7 +34,7 @@
         (binding [commando-utils/*execute-config*
                   {:debug-result false
                    :error-data-string false}]
-          (commando/execute {:commando/fn command-builtin/command-fn-spec}
+          (commando/execute [command-builtin/command-fn-spec]
             {:commando/fn "STRING"
              :args [[1 2 3] [3 2 1]]}))
         (fn [error]
@@ -53,7 +53,7 @@
         (binding [commando-utils/*execute-config*
                   {:debug-result false
                    :error-data-string false}]
-          (commando/execute {:commando/fn command-builtin/command-fn-spec}
+          (commando/execute [command-builtin/command-fn-spec]
             {:commando/fn (fn [& [v1 v2]] (reduce + (map * v1 v2)))
              :args "BROKEN"}))
         (fn [error]
@@ -73,8 +73,8 @@
     (is (=
           {:value 1, :result-simple 2, :result-with-deps 2}
           (:instruction
-           (commando/execute {:commando/apply command-builtin/command-apply-spec
-                              :commando/from command-builtin/command-from-spec}
+           (commando/execute [command-builtin/command-apply-spec
+                              command-builtin/command-from-spec]
              {:value 1
               :result-simple {:commando/apply {:value 1}
                               :=> [:fn (fn [e] (-> e :value inc))]}
@@ -91,8 +91,8 @@
   (testing "Successfull test cases"
     (is (= {:a 1, :vec 1, :vec-map 1, :result-of-another 1}
           (get-in
-            (commando/execute {:commando/fn command-builtin/command-fn-spec
-                               :commando/from command-builtin/command-from-spec}
+            (commando/execute [command-builtin/command-fn-spec
+                               command-builtin/command-from-spec]
               {"values" {:a 1
                          :vec [1]
                          :vec-map [{:a 1}]
@@ -110,7 +110,7 @@
             :d {:result [4 4]},
             :e {:result [5 5]}}
           (:instruction
-           (commando/execute {:commando/from command-builtin/command-from-spec}
+           (commando/execute [command-builtin/command-from-spec]
              {:a {:value 1
                   :result {:commando/from ["../" :value]}}
               :b {:value 2
@@ -128,7 +128,7 @@
             "d" {"result" [4 4]},
             "e" {"result" [5 5]}}
           (:instruction
-           (commando/execute {:commando/from command-builtin/command-from-spec}
+           (commando/execute [command-builtin/command-from-spec]
              {"a" {"value" 1
                    "result" {"commando-from" ["../" "value"]}}
               "b" {"value" 2
@@ -143,8 +143,8 @@
     #?(:clj
        (is (= {:get-kwd 1, :fn-fn 2, :fn-symbol 2, :fn-var 2}
              (get-in
-               (commando/execute {:commando/fn command-builtin/command-fn-spec
-                                  :commando/from command-builtin/command-from-spec}
+               (commando/execute [command-builtin/command-fn-spec
+                                  command-builtin/command-from-spec]
                  {"value" {:kwd 1}
                   "result" {:get-kwd {:commando/from ["value"] :=> [:get :kwd]}
                             :fn-fn {:commando/from ["value"] :=> [:fn (fn [{:keys [kwd]}] (inc kwd))]}
@@ -154,8 +154,8 @@
          "commando/from :=> drivers. CLJ: :get/:fn with fn/keyword/var/symbol")
        :cljs (is (= {:get-kwd 1, :fn-fn 2}
                    (get-in
-                     (commando/execute {:commando/fn command-builtin/command-fn-spec
-                                        :commando/from command-builtin/command-from-spec}
+                     (commando/execute [command-builtin/command-fn-spec
+                                        command-builtin/command-from-spec]
                        {"value" {:kwd 1}
                         "result" {:get-kwd {:commando/from ["value"] :=> [:get :kwd]}
                                   :fn-fn {:commando/from ["value"] :=> [:fn (fn [{:keys [kwd]}] (inc kwd))]}}})
@@ -165,7 +165,7 @@
   (testing "Anchor navigation"
     (is (= {:section {:__anchor "root" :price 10 :ref 10}}
            (:instruction
-            (commando/execute {:commando/from command-builtin/command-from-spec}
+            (commando/execute [command-builtin/command-from-spec]
               {:section {:__anchor "root"
                          :price 10
                          :ref {:commando/from ["@root" :price]}}})))
@@ -173,7 +173,7 @@
     (is (= {:items [{:__anchor "item" :price 10 :ref 10}
                     {:__anchor "item" :price 20 :ref 20}]}
            (:instruction
-            (commando/execute {:commando/from command-builtin/command-from-spec}
+            (commando/execute [command-builtin/command-from-spec]
               {:items [{:__anchor "item"
                         :price 10
                         :ref {:commando/from ["@item" :price]}}
@@ -185,7 +185,7 @@
                       :base-price 5
                       :section {:__anchor "section" :price 10 :sibling-price 5}}}
            (:instruction
-            (commando/execute {:commando/from command-builtin/command-from-spec}
+            (commando/execute [command-builtin/command-from-spec]
               {:catalog {:__anchor "root"
                          :base-price 5
                          :section {:__anchor "section"
@@ -202,7 +202,7 @@
               {:price-1 5
                :price-2 10}}}}
           (:instruction
-           (commando/execute {:commando/from command-builtin/command-from-spec}
+           (commando/execute [command-builtin/command-from-spec]
              {:root-1
               {:__anchor "root-1"
                :price 5
@@ -217,7 +217,7 @@
   (testing "Failure test cases"
     (is
       (helpers/status-map-contains-error?
-        (commando/execute {:commando/from command-builtin/command-from-spec}
+        (commando/execute [command-builtin/command-from-spec]
           {:ref {:commando/from ["@nonexistent" :value]}})
         {:message "Commando. Point dependency failed: key ':commando/from' references non-existent path [\"@nonexistent\" :value]",
          :path [:ref],
@@ -225,7 +225,7 @@
       "Anchor not found: should produce error with :anchor key in data")
     (is
       (helpers/status-map-contains-error?
-        (commando/execute {:commando/from command-builtin/command-from-spec}
+        (commando/execute [command-builtin/command-from-spec]
           {"source" {:a 1 :b 2}
            "missing" {:commando/from ["UNEXISING"]}})
         {:message "Commando. Point dependency failed: key ':commando/from' references non-existent path [\"UNEXISING\"]",
@@ -234,7 +234,7 @@
       "Waiting on error, bacause commando/from seding to unexising path")
     (is
       (helpers/status-map-contains-error?
-        (commando/execute {:commando/from command-builtin/command-from-spec}
+        (commando/execute [command-builtin/command-from-spec]
           {"source" {:a 1 :b 2}
            "missing" {"commando-from" ["UNEXISING"]}})
         {:message "Commando. Point dependency failed: key 'commando-from' references non-existent path [\"UNEXISING\"]",
@@ -246,7 +246,7 @@
         (binding [commando-utils/*execute-config*
                   {:debug-result false
                    :error-data-string false}]
-          (commando/execute {:commando/from command-builtin/command-from-spec}
+          (commando/execute [command-builtin/command-from-spec]
             {"value" 1
              "result" {:commando/from ["value"]
                        "commando-from" ["value"]}}))
@@ -263,7 +263,7 @@
                     {:debug-result false
                      :error-data-string false}]
             (commando/execute
-              {:commando/from command-builtin/command-from-spec}
+              [command-builtin/command-from-spec]
               {:commando/from "BROKEN"}))
           (fn [error]
             (=
@@ -289,7 +289,7 @@
     (testing "Successfull test cases"
       (is (= {:color "#FF0000" :number 10 :deep 42}
             (:instruction
-             (commando/execute {:commando/context ctx-spec}
+             (commando/execute [ctx-spec]
                {:color  {:commando/context [:colors :red]}
                 :number {:commando/context [:numbers 0]}
                 :deep   {:commando/context [:nested :a :b :c]}})))
@@ -297,14 +297,14 @@
 
       (is (= {:val "#0000FF" :count 2}
             (:instruction
-             (commando/execute {:commando/context ctx-spec}
+             (commando/execute [ctx-spec]
                {:count {:commando/context [:colors] :=> [:fn count]}
                 :val {:commando/context [:colors] :=> [:get :blue]}})))
         "Should apply :=> driver to resolved value")
 
       (is (= {:val-default "fallback" :val-nil nil}
             (:instruction
-             (commando/execute {:commando/context ctx-spec}
+             (commando/execute [ctx-spec]
                {:val-default {:commando/context [:nonexistent] :default "fallback"}
                 :val-nil     {:commando/context [:nonexistent] :default nil}})))
         "Should return :default value when path not found, in other way 'nil' value without exception ")
@@ -313,7 +313,7 @@
             str-spec (command-builtin/command-context-spec str-ctx)]
         (is (= {"val" "Ukrainian" "val-default" "none" "val-get" "English"}
               (:instruction
-               (commando/execute {:commando/context str-spec}
+               (commando/execute [str-spec]
                  {"val"          {"commando-context" ["lang" "ua"]}
                   "val-get"      {"commando-context" ["lang"] "=>" ["get" "en"]}
                   "val-default"  {"commando-context" ["missing"] "default" "none"}})))
@@ -322,7 +322,7 @@
       (is (helpers/status-map-contains-error?
             (binding [commando-utils/*execute-config*
                       {:debug-result false :error-data-string false}]
-              (commando/execute {:commando/context ctx-spec}
+              (commando/execute [ctx-spec]
                 {:val {:commando/context "NOT-A-PATH"}}))
             (fn [error]
               (= (-> error :error :data)
@@ -334,7 +334,7 @@
       (is (helpers/status-map-contains-error?
             (binding [commando-utils/*execute-config*
                       {:debug-result false :error-data-string false}]
-              (commando/execute {:commando/context ctx-spec}
+              (commando/execute [ctx-spec]
                 {:val {:commando/context [:colors] "commando-context" ["colors"]}}))
             (fn [error]
               (= (-> error :error :data)
@@ -364,8 +364,8 @@
     (is (=
           {:vector1 [1 2 3], :vector2 [3 2 1], :result-simple 10, :result-with-deps 10}
           (:instruction
-           (commando/execute {:commando/mutation command-builtin/command-mutation-spec
-                              :commando/from command-builtin/command-from-spec}
+           (commando/execute [command-builtin/command-mutation-spec
+                              command-builtin/command-from-spec]
              {:vector1 [1 2 3]
               :vector2 [3 2 1]
               :result-simple {:commando/mutation :dot-product
@@ -378,8 +378,8 @@
     (is (=
           {"vector1" [1 2 3], "vector2" [3 2 1], "result-simple" 10, "result-with-deps" 10}
           (:instruction
-           (commando/execute {:commando/mutation command-builtin/command-mutation-spec
-                              :commando/from command-builtin/command-from-spec}
+           (commando/execute [command-builtin/command-mutation-spec
+                              command-builtin/command-from-spec]
              {"vector1" [1 2 3]
               "vector2" [3 2 1]
               "result-simple" {"commando-mutation" "dot-product"
@@ -395,7 +395,7 @@
         (binding [commando-utils/*execute-config*
                   {:debug-result false
                    :error-data-string false}]
-          (commando/execute {:commando/mutation command-builtin/command-mutation-spec}
+          (commando/execute [command-builtin/command-mutation-spec]
             {:commando/mutation :dot-product
              "commando-mutation" "dot-product"
              "vector1" [1 2 3]
@@ -417,7 +417,7 @@
         (binding [commando-utils/*execute-config*
                   {:debug-result false
                    :error-data-string false}]
-          (commando/execute {:commando/mutation command-builtin/command-mutation-spec}
+          (commando/execute [command-builtin/command-mutation-spec]
             {:commando/mutation (fn [] "BROKEN")}))
         (fn [error]
           (=
@@ -431,7 +431,7 @@
         (binding [commando-utils/*execute-config*
                   {:debug-result false
                    :error-data-string false}]
-          (commando/execute {:commando/mutation command-builtin/command-mutation-spec}
+          (commando/execute [command-builtin/command-mutation-spec]
             {:commando/mutation :dot-product
              :vector1 [1 "_" 3]
              :vector2 [3 2 1]}))
@@ -490,10 +490,10 @@
         {:vector-dot-1 32, :vector-dot-2 320}
         (:instruction
          (commando/execute
-           {:commando/macro command-builtin/command-macro-spec
-            :commando/fn command-builtin/command-fn-spec
-            :commando/from command-builtin/command-from-spec
-            :commando/apply command-builtin/command-apply-spec}
+           [command-builtin/command-macro-spec
+            command-builtin/command-fn-spec
+            command-builtin/command-from-spec
+            command-builtin/command-apply-spec]
            {:vector-dot-1
             {:commando/macro :string-vectors-dot-product
              :vector1-str ["1" "2" "3"]
@@ -508,10 +508,10 @@
         {"vector-dot-1" 32, "vector-dot-2" 320}
         (:instruction
          (commando/execute
-           {:commando/macro command-builtin/command-macro-spec
-            :commando/fn command-builtin/command-fn-spec
-            :commando/from command-builtin/command-from-spec
-            :commando/apply command-builtin/command-apply-spec}
+           [command-builtin/command-macro-spec
+            command-builtin/command-fn-spec
+            command-builtin/command-from-spec
+            command-builtin/command-apply-spec]
            {"vector-dot-1"
             {"commando-macro" "string-vectors-dot-product"
              "vector1-str" ["1" "2" "3"]
@@ -528,10 +528,10 @@
                   {:debug-result false
                    :error-data-string false}]
           (commando/execute
-            {:commando/macro command-builtin/command-macro-spec
-             :commando/fn command-builtin/command-fn-spec
-             :commando/from command-builtin/command-from-spec
-             :commando/apply command-builtin/command-apply-spec}
+            [command-builtin/command-macro-spec
+             command-builtin/command-fn-spec
+             command-builtin/command-from-spec
+             command-builtin/command-apply-spec]
             {:commando/macro :string-vectors-dot-product
              "commando-macro" "string-vectors-dot-product"
              "vector1-str" ["1" "2" "3"]
@@ -553,7 +553,7 @@
         (binding [commando-utils/*execute-config*
                   {:debug-result false
                    :error-data-string false}]
-          (commando/execute {:commando/macro command-builtin/command-macro-spec}
+          (commando/execute [command-builtin/command-macro-spec]
             {:commando/macro (fn [])}))
         (fn [error]
           (=

--- a/test/unit/commando/commands/builtin_test.cljc
+++ b/test/unit/commando/commands/builtin_test.cljc
@@ -77,29 +77,10 @@
                               :commando/from command-builtin/command-from-spec}
              {:value 1
               :result-simple {:commando/apply {:value 1}
-                              := (fn [e] (-> e :value inc))}
+                              :=> [:fn (fn [e] (-> e :value inc))]}
               :result-with-deps {:commando/apply {:commando/from [:value]}
-                                 := inc}})))
-      "Uncorrectly processed :commando/apply"))
-  (testing "Failure test cases"
-    (is
-      (helpers/status-map-contains-error?
-        (binding [commando-utils/*execute-config*
-                  {:debug-result false
-                   :error-data-string false}]
-          (commando/execute {:commando/apply command-builtin/command-apply-spec}
-            {:commando/apply {:value 1}
-             := "STRING"}))
-        (fn [error]
-          (=
-            (-> error :error :data)
-            {:command-type :commando/apply,
-             :reason
-             {:= [#?(:clj "Expected a fn, var of fn, symbol resolving to a fn"
-                     :cljs "Expected a fn")]},
-             :path [],
-             :value {:commando/apply {:value 1}, := "STRING"}})))
-      "Waiting on error, bacause commando/fn has wrong type for :commando/fn")))
+                                 :=> [:fn inc]}})))
+      "Uncorrectly processed :commando/apply")))
 
 ;; ===========================
 ;; FROM-SPEC
@@ -160,28 +141,26 @@
                              {"commando-from" ["./" "../" 0]}]}})))
       "Uncorrect extracting \"commando-from\" by relative path")
     #?(:clj
-       (is (= {:=-keyword 1, :=-fn 2, :=-symbol 2, :=-var 2}
+       (is (= {:get-kwd 1, :fn-fn 2, :fn-symbol 2, :fn-var 2}
              (get-in
                (commando/execute {:commando/fn command-builtin/command-fn-spec
                                   :commando/from command-builtin/command-from-spec}
                  {"value" {:kwd 1}
-                  "result" {:=-keyword {:commando/from ["value" ] := :kwd}
-                            :=-fn {:commando/from ["value"] := (fn [{:keys [kwd]}] (inc kwd))}
-                            :=-symbol {:commando/from ["value" :kwd] := 'inc}
-                            :=-var {:commando/from ["value" :kwd] := #'inc}}})
-               [:instruction "result"])
-             )
-         "Uncorrect commando/from ':=' applicator. CLJ Supports: fn/keyword/var/symbol")
-       :cljs (is (= {:=-keyword 1, :=-fn 2}
+                  "result" {:get-kwd {:commando/from ["value"] :=> [:get :kwd]}
+                            :fn-fn {:commando/from ["value"] :=> [:fn (fn [{:keys [kwd]}] (inc kwd))]}
+                            :fn-symbol {:commando/from ["value" :kwd] :=> [:fn 'inc]}
+                            :fn-var {:commando/from ["value" :kwd] :=> [:fn #'inc]}}})
+               [:instruction "result"]))
+         "commando/from :=> drivers. CLJ: :get/:fn with fn/keyword/var/symbol")
+       :cljs (is (= {:get-kwd 1, :fn-fn 2}
                    (get-in
                      (commando/execute {:commando/fn command-builtin/command-fn-spec
                                         :commando/from command-builtin/command-from-spec}
                        {"value" {:kwd 1}
-                        "result" {:=-keyword {:commando/from ["value" ] := :kwd}
-                                  :=-fn {:commando/from ["value"] := (fn [{:keys [kwd]}] (inc kwd))}}})
-                     [:instruction "result"])
-                   )
-               "Uncorrect commando/from ':=' applicator. CLJS Supports: fn/keyword")))
+                        "result" {:get-kwd {:commando/from ["value"] :=> [:get :kwd]}
+                                  :fn-fn {:commando/from ["value"] :=> [:fn (fn [{:keys [kwd]}] (inc kwd))]}}})
+                     [:instruction "result"]))
+               "commando/from :=> drivers. CLJS: :get/:fn with fn/keyword")))
   ;; -------------------
   (testing "Anchor navigation"
     (is (= {:section {:__anchor "root" :price 10 :ref 10}}
@@ -294,23 +273,7 @@
                :value {:commando/from "BROKEN"}
                :reason {:commando/from ["commando/from should be a sequence path to value in Instruction: [:some 2 \"value\"]"]}})))
       "Waiting on error, ':validate-params-fn' for commando/from. Corrupted path \"BROKEN\" ")
-    (is (helpers/status-map-contains-error?
-          (binding [commando-utils/*execute-config*
-                    {:debug-result false
-                     :error-data-string false}]
-            (commando/execute
-              {:commando/from command-builtin/command-from-spec}
-              {:v 1
-               :a {:commando/from [:v] := ["BROKEN"]}}))
-          (fn [error]
-            (=
-              (-> error :error :data)
-              {:command-type :commando/from,
-               :reason {:= [#?(:clj "Expected a fn, var of fn, symbol resolving to a fn"
-                               :cljs "Expected a fn")
-                            "should be a string"]},
-               :path [:a], :value {:commando/from [:v], := ["BROKEN"]}})))
-      "Waiting on error, ':validate-params-fn' for commando/from. Wrong type for optional ':=' applicator")))
+))
 
 ;; ===========================
 ;; CONTEXT-SPEC
@@ -335,9 +298,9 @@
       (is (= {:val "#0000FF" :count 2}
             (:instruction
              (commando/execute {:commando/context ctx-spec}
-               {:count {:commando/context [:colors] := count}
-                :val {:commando/context [:colors] := :blue}})))
-        "Should apply := fn to resolved value")
+               {:count {:commando/context [:colors] :=> [:fn count]}
+                :val {:commando/context [:colors] :=> [:get :blue]}})))
+        "Should apply :=> driver to resolved value")
 
       (is (= {:val-default "fallback" :val-nil nil}
             (:instruction
@@ -348,11 +311,11 @@
 
       (let [str-ctx {"lang" {"ua" "Ukrainian" "en" "English"}}
             str-spec (command-builtin/command-context-spec str-ctx)]
-        (is (= {"val" "Ukrainian" "val-default" "none" "val-=" "English"}
+        (is (= {"val" "Ukrainian" "val-default" "none" "val-get" "English"}
               (:instruction
                (commando/execute {:commando/context str-spec}
                  {"val"          {"commando-context" ["lang" "ua"]}
-                  "val-="        {"commando-context" ["lang"] "=" "en"}
+                  "val-get"      {"commando-context" ["lang"] "=>" ["get" "en"]}
                   "val-default"  {"commando-context" ["missing"] "default" "none"}})))
           "String keys test")))
     (testing "Failure test cases"
@@ -492,7 +455,7 @@
 ;; ===========================
 
 (defn string-vector-dot-product [vector1-str vector2-str]
-  {:= :dot-product
+  {:=> [:get :dot-product]
    :commando/apply
    {:vector1-str vector1-str
     :vector2-str vector2-str

--- a/test/unit/commando/commands/query_dsl_test.cljc
+++ b/test/unit/commando/commands/query_dsl_test.cljc
@@ -39,10 +39,10 @@
 
 (def registry
   (commando/registry-create
-   {:commando/resolve command-query-dsl/command-resolve-spec
-    :commando/fn command-builtin/command-fn-spec
-    :commando/from command-builtin/command-from-spec
-    :commando/apply command-builtin/command-apply-spec}))
+   [command-query-dsl/command-resolve-spec
+    command-builtin/command-fn-spec
+    command-builtin/command-from-spec
+    command-builtin/command-apply-spec]))
 
 (defn get-permissions-by-name [permission-name]
   (first (filter (fn [x] (= permission-name (:permission-name x))) (:permissions db))))

--- a/test/unit/commando/core_test.cljc
+++ b/test/unit/commando/core_test.cljc
@@ -511,7 +511,7 @@
                          :needs-prepare {:commando/from [:m-orders :prepare]}}}
    :z-reports {:daily {:commando/from [:m-orders]}
                :weekly {:commando/from [:m-orders :finalize :needs-create]
-                        := :create}}
+                        :=> [:get :create]}}
    :a-analytics {:summary {:commando/from [:z-reports :weekly]}
                  :export {:commando/from [:a-analytics :summary]}}})
 
@@ -526,14 +526,14 @@
    :instruction {"source" {:data 42
                            :extra "info"}
                  "transformed" {:commando/from ["source"]
-                                := :data}}
+                                :=> [:get :data]}}
    :registry (commando/registry-create {:commando/from cmds-builtin/command-from-spec})
    :internal/cm-running-order [(cm/->CommandMapPath ["transformed"] cmds-builtin/command-from-spec)]})
 
 (def apply-transformation-execution-map
   {:status :ok
    :instruction {"processed" {:commando/apply [1 2 3 4 5]
-                              := #(apply + %)}}
+                              :=> [:fn #(apply + %)]}}
    :registry (commando/registry-create {:commando/apply cmds-builtin/command-apply-spec})
    :internal/cm-running-order [(cm/->CommandMapPath ["processed"] cmds-builtin/command-apply-spec)]})
 
@@ -569,7 +569,7 @@
 (def apply-command
   {:status :ok
    :instruction {"transform" {:commando/apply {"data" 10}
-                              := #(get % "data")}}
+                              :=> [:fn #(get % "data")]}}
    :registry (commando/registry-create {:commando/apply cmds-builtin/command-apply-spec})
    :internal/cm-running-order [(cm/->CommandMapPath ["transform"] cmds-builtin/command-apply-spec)]})
 
@@ -684,20 +684,20 @@
 
 (def apply-instruction
   {"transform" {:commando/apply [1 2 3]
-                := count}})
+                :=> [:fn count]}})
 
 (def mixed-instruction
   {"source" 100
    "doubled" {:commando/fn *
               :args [{:commando/from ["source"]} 2]}
    "processed" {:commando/apply {:commando/from ["doubled"]}
-                := str}
+                :=> [:fn str]}
    "metadata" {:test/add-id "info"}})
 
 (def transform-instruction
   {"data" {:nested {:value 42}}
    "extracted" {:commando/from ["data"]
-                := #(get-in % [:nested :value])}})
+                :=> [:get-in [:nested :value]]}})
 
 ;; Complex dependency scenario instructions
 (def linear-chain-instruction
@@ -819,17 +819,17 @@
 ;; Instruction-command test instructions
 (def sum-collection-instruction
   {"0" {:commando/from ["=SUM"]
-        := (fn [e] (apply + e))}
+        :=> [:fn (fn [e] (apply + e))]}
    "1" 1
    "2" {:container {:commando/from ["1"]
-                    := inc}}
+                    :=> [:fn inc]}}
    "3" {:container {:commando/from ["2"]
-                    := :container}}
+                    :=> [:get :container]}}
    "=SUM" [{:commando/from ["1"]}
            {:commando/from ["2"]
-            := :container}
+            :=> [:get :container]}
            {:commando/from ["3"]
-            := :container}]})
+            :=> [:get :container]}]})
 
 (def unexisting-path-instruction
   {"1" 1
@@ -930,23 +930,23 @@
 
 (def base-instruction-compiler
   {"0" {:commando/from ["=SUM"]
-        := (fn [e] (apply + e))}
+        :=> [:fn (fn [e] (apply + e))]}
    "1" 1
    "2" {"container" {:commando/from ["1"]}}
    "3" {"container" {:commando/from ["2"]
-                     := "container"}}
+                     :=> [:get "container"]}}
    "=SUM" [{:commando/from ["1"]}
            {:commando/from ["2"]
-            := "container"}
+            :=> [:get "container"]}
            {:commando/from ["3"]
-            := "container"}]})
+            :=> [:get "container"]}]})
 
 (def toplevel-vector-instruction
   [{:value 10}
    {:commando/from [0 :value]
-    := inc}
+    :=> [:fn inc]}
    {:commando/from [1]
-    := (partial * 2)}])
+    :=> [:fn (partial * 2)]}])
 
 (deftest execute-test
   (testing "Status"
@@ -974,8 +974,11 @@
               "Commando. Point dependency failed: key ':commando/from' references non-existent path [\"UNEXISTING_PATH\"]",
               :path ["2" :container],
               :command {:commando/from ["UNEXISTING_PATH"]}}])))
-    (is (commando/failed? (commando/execute {:commando/apply cmds-builtin/command-apply-spec} {"plain" {:commando/apply [1 2 3]}}))
-        "Missing := parameter causes validation failure"))
+    (is (commando/ok? (commando/execute {:commando/apply cmds-builtin/command-apply-spec} {"plain" {:commando/apply [1 2 3]}}))
+        "Missing :=> — identity pass-through via default :get-in driver")
+    (is (= [1 2 3]
+           (get-in (commando/execute {:commando/apply cmds-builtin/command-apply-spec} {"plain" {:commando/apply [1 2 3]}}) [:instruction "plain"]))
+        "Without :=>, :commando/apply returns its value as-is"))
   (testing "Basic cases"
     (is (= 42 (get-in (commando/execute registry-from-spec test-instruction) [:instruction "ref"]))
         "Command executed correctly")
@@ -1041,10 +1044,10 @@
     (is (= {"0" {:final "5"}}
            (->> {"0" {:commando/apply {"1" {:commando/apply {"2" {:commando/apply {"3" {:commando/apply {"4" {:final
                                                                                                               "5"}}
-                                                                                        := #(get % "4")}}
-                                                                  := #(get % "3")}}
-                                            := #(get % "2")}}
-                      := #(get % "1")}}
+                                                                                        :=> [:get "4"]}}
+                                                                  :=> [:get "3"]}}
+                                            :=> [:get "2"]}}
+                      :=> [:get "1"]}}
                 (commando/execute {:commando/apply cmds-builtin/command-apply-spec})
                 :instruction))
         "Commands inside commands are executed correctly")
@@ -1053,52 +1056,52 @@
                                                    {"source" {:user-name "john"
                                                               :age 25}
                                                     "name" {:commando/from ["source"]
-                                                            := :user-name}}))
+                                                            :=> [:get :user-name]}}))
                    ["name"]))
-        "Value extracted correctly with := in commando/from using keyword")
+        "Value extracted with :=> [:get] in commando/from using keyword")
     (is (= 25
            (get-in (:instruction (commando/execute {:commando/from cmds-builtin/command-from-spec}
                                                    {"source" {"age" 25}
                                                     "age" {:commando/from ["source"]
-                                                           := "age"}}))
+                                                           :=> [:get "age"]}}))
                    ["age"]))
-        "Value extracted correctly with := in commando/from using string")
+        "Value extracted with :=> [:get] in commando/from using string")
     (is (= 15
            (get-in (:instruction (commando/execute {:commando/from cmds-builtin/command-from-spec}
                                                    {"numbers" [1 2 3 4 5]
                                                     "sum" {:commando/from ["numbers"]
-                                                           := #(reduce + %)}}))
+                                                           :=> [:fn #(reduce + %)]}}))
                    ["sum"]))
-        "commando/from  := syntax applying function works")
+        "commando/from :=> [:fn] applying function works")
     (is (= 1
            (get-in (:instruction (commando/execute {:commando/from cmds-builtin/command-from-spec}
                                                    {"numbers" [1 2 3 4 5]
                                                     "first" {:commando/from ["numbers"]
-                                                             := first}}))
+                                                             :=> [:fn first]}}))
                    ["first"]))
-        "commando/from  := syntax applying function works")
+        "commando/from :=> [:fn] applying function works")
     (is (nil? (get-in (:instruction (commando/execute {:commando/from cmds-builtin/command-from-spec}
                                                       {"source" {:a 1
                                                                  :b 2}
                                                        "missing" {:commando/from ["source"]
-                                                                  := :nonexistent}}))
+                                                                  :=> [:get :nonexistent]}}))
                       ["missing"]))
-        "commando/from := nil returned when value is missing")
+        "commando/from :=> [:get] nil returned when key is missing")
     (is (nil? (get-in (:instruction (commando/execute {:commando/from cmds-builtin/command-from-spec}
                                                       {"source" {:a 1
                                                                  :b 2}
                                                        "missing" {:commando/from ["source"]
-                                                                  := "bóg"}}))
+                                                                  :=> [:get "bóg"]}}))
                       ["missing"]))
-        "commando/from := nil returned when value is missing")
+        "commando/from :=> [:get] nil returned when key is missing")
     (is (= '(20 40 60)
            (get-in (:instruction (commando/execute {:commando/apply cmds-builtin/command-apply-spec
                                                     :commando/from cmds-builtin/command-from-spec}
                                                    {"base" [10 20 30]
                                                     "doubled" {:commando/apply {:commando/from ["base"]}
-                                                               := #(map (partial * 2) %)}}))
+                                                               :=> [:fn #(map (partial * 2) %)]}}))
                    ["doubled"]))
-        "commando/apply works with just a command as a value")
+        "commando/apply works with :=> [:fn] driver")
     (testing "Single command types"
       (is (= 10 (get-in (commando/execute {:commando/from cmds-builtin/command-from-spec} from-instruction) [:instruction "b"])))
       (is (= 6 (get-in (commando/execute {:commando/fn cmds-builtin/command-fn-spec} fn-instruction) [:instruction "calc"])))

--- a/test/unit/commando/core_test.cljc
+++ b/test/unit/commando/core_test.cljc
@@ -18,8 +18,8 @@
 
 (def registry
   (->
-    {:commando/from cmds-builtin/command-from-spec
-     :test/add-id test-add-id-command}
+    [cmds-builtin/command-from-spec
+     test-add-id-command]
     (commando-registry/build)
     (commando-registry/enrich-runtime-registry)))
 
@@ -441,7 +441,7 @@
           none-cmd (cm/->CommandMapPath [:standalone] none-command)
           test-status-map {:status :ok
                            :instruction {:standalone {:test/none :independent}}
-                           :registry {:test/none none-command}
+                           :registry (commando/registry-create [none-command])
                            :internal/cm-list [none-cmd]}
           result (#'commando/build-deps-tree test-status-map)
           deps (:internal/cm-dependency result)]
@@ -518,7 +518,7 @@
 (def mutation-timestamp-execution-map
   {:status :ok
    :instruction {"timestamp" {:commando/mutation :time/current-dd-mm-yyyy-hh-mm-ss}}
-   :registry (commando/registry-create {:commando/mutation cmds-builtin/command-mutation-spec})
+   :registry (commando/registry-create [cmds-builtin/command-mutation-spec])
    :internal/cm-running-order [(cm/->CommandMapPath ["timestamp"] cmds-builtin/command-mutation-spec)]})
 
 (def from-transformation-execution-map
@@ -527,14 +527,14 @@
                            :extra "info"}
                  "transformed" {:commando/from ["source"]
                                 :=> [:get :data]}}
-   :registry (commando/registry-create {:commando/from cmds-builtin/command-from-spec})
+   :registry (commando/registry-create [cmds-builtin/command-from-spec])
    :internal/cm-running-order [(cm/->CommandMapPath ["transformed"] cmds-builtin/command-from-spec)]})
 
 (def apply-transformation-execution-map
   {:status :ok
    :instruction {"processed" {:commando/apply [1 2 3 4 5]
                               :=> [:fn #(apply + %)]}}
-   :registry (commando/registry-create {:commando/apply cmds-builtin/command-apply-spec})
+   :registry (commando/registry-create [cmds-builtin/command-apply-spec])
    :internal/cm-running-order [(cm/->CommandMapPath ["processed"] cmds-builtin/command-apply-spec)]})
 
 ;; ================================
@@ -549,34 +549,34 @@
 
 (def basic-success-map
   {:status :ok
-   :registry (commando/registry-create {:test/add-id test-add-id-command})
+   :registry (commando/registry-create [test-add-id-command])
    :internal/cm-running-order []})
 
 (def from-command
   {:status :ok
    :instruction {"source" 42
                  "ref" {:commando/from ["source"]}}
-   :registry (commando/registry-create {:commando/from cmds-builtin/command-from-spec})
+   :registry (commando/registry-create [cmds-builtin/command-from-spec])
    :internal/cm-running-order [(cm/->CommandMapPath ["ref"] cmds-builtin/command-from-spec)]})
 
 (def fn-command
   {:status :ok
    :instruction {"calc" {:commando/fn +
                          :args [1 2 3]}}
-   :registry (commando/registry-create {:commando/fn cmds-builtin/command-fn-spec})
+   :registry (commando/registry-create [cmds-builtin/command-fn-spec])
    :internal/cm-running-order [(cm/->CommandMapPath ["calc"] cmds-builtin/command-fn-spec)]})
 
 (def apply-command
   {:status :ok
    :instruction {"transform" {:commando/apply {"data" 10}
                               :=> [:fn #(get % "data")]}}
-   :registry (commando/registry-create {:commando/apply cmds-builtin/command-apply-spec})
+   :registry (commando/registry-create [cmds-builtin/command-apply-spec])
    :internal/cm-running-order [(cm/->CommandMapPath ["transform"] cmds-builtin/command-apply-spec)]})
 
 (def add-id-command-execution
   {:status :ok
    :instruction {"cmd" {:test/add-id "some-value"}}
-   :registry (commando/registry-create {:test/add-id test-add-id-command})
+   :registry (commando/registry-create [test-add-id-command])
    :internal/cm-running-order [(cm/->CommandMapPath ["cmd"] test-add-id-command)]})
 
 (def dependency-scenarios
@@ -620,13 +620,13 @@
 (def timeout-command-execution-map
   {:status :ok
    :instruction {"cmd" {:fail true}}
-   :registry (commando/registry-create {:test/failing (:timeout-cmd failing-commands)})
+   :registry (commando/registry-create [(:timeout-cmd failing-commands)])
    :internal/cm-running-order [(cm/->CommandMapPath ["cmd"] (:timeout-cmd failing-commands))]})
 
 (def bad-command-execution-map
   {:status :ok
    :instruction {"bad" {:will-fail true}}
-   :registry (commando/registry-create {:test/bad (:bad-cmd failing-commands)})
+   :registry (commando/registry-create [(:bad-cmd failing-commands)])
    :internal/cm-running-order [(cm/->CommandMapPath ["bad"] (:bad-cmd failing-commands))]})
 
 (def midway-fail-execution-map
@@ -634,8 +634,8 @@
    :instruction {"good" {:test/add-id "works"}
                  "bad" {:will-fail true}
                  "never" {:test/add-id "should-not-execute"}}
-   :registry (commando/registry-create {:test/add-id test-add-id-command
-                                        :test/bad (:bad-cmd failing-commands)})
+   :registry (commando/registry-create [test-add-id-command
+                                        (:bad-cmd failing-commands)])
    :internal/cm-running-order [(cm/->CommandMapPath ["good"] test-add-id-command)
                                (cm/->CommandMapPath ["bad"] (:bad-cmd failing-commands))
                                (cm/->CommandMapPath ["never"] test-add-id-command)]})
@@ -649,13 +649,13 @@
 (def nil-handler-execution-map
   {:status :ok
    :instruction {"nil-handler" {:handle-nil nil}}
-   :registry (commando/registry-create {:test/nil-handler nil-handler-command})
+   :registry (commando/registry-create [nil-handler-command])
    :internal/cm-running-order [(cm/->CommandMapPath ["nil-handler"] nil-handler-command)]})
 
 (def deep-nested-execution-map
   {:status :ok
    :instruction {"level1" {"level2" {"level3" {"deep" {:test/add-id "deep-value"}}}}}
-   :registry (commando/registry-create {:test/add-id test-add-id-command})
+   :registry (commando/registry-create [test-add-id-command])
    :internal/cm-running-order [(cm/->CommandMapPath ["level1" "level2" "level3" "deep"] test-add-id-command)]})
 
 (def large-commands-execution-map
@@ -663,16 +663,16 @@
         instruction (into {} (map #(vector % {:test/add-id (str "value-" %)}) (range 20)))]
     {:status :ok
      :instruction instruction
-     :registry (commando/registry-create {:test/add-id test-add-id-command})
+     :registry (commando/registry-create [test-add-id-command])
      :internal/cm-running-order commands}))
 
 (def full-registry-all
-  {:commando/from cmds-builtin/command-from-spec
-   :commando/fn cmds-builtin/command-fn-spec
-   :commando/apply cmds-builtin/command-apply-spec
-   :commando/mutation cmds-builtin/command-mutation-spec
-   :commando/macro cmds-builtin/command-macro-spec
-   :test/add-id test-add-id-command})
+  [cmds-builtin/command-from-spec
+   cmds-builtin/command-fn-spec
+   cmds-builtin/command-apply-spec
+   cmds-builtin/command-mutation-spec
+   cmds-builtin/command-macro-spec
+   test-add-id-command])
 
 (def from-instruction
   {"a" 10
@@ -724,9 +724,9 @@
              "child2" {:commando/from ["parent" "child1"]}}})
 
 ;; Error scenarios data and registries
-(def error-registry {:commando/from cmds-builtin/command-from-spec
-                     :test/add-id test-add-id-command
-                     :test/failing (:timeout-cmd failing-commands)})
+(def error-registry [cmds-builtin/command-from-spec
+                     test-add-id-command
+                     (:timeout-cmd failing-commands)])
 
 (def invalid-cmd
   {:type :test/invalid
@@ -793,7 +793,7 @@
    :dependencies {:mode :point
                   :point-key [:ARG]}})
 
-(def custom-registry {:OP custom-op-cmd :ARG custom-arg-cmd})
+(def custom-registry [custom-op-cmd custom-arg-cmd])
 
 ;; Helper-integration instructions
 (def value-ref-instruction
@@ -857,13 +857,13 @@
                     1]}})
 
 ;; Test data for execute-function-comprehensive-test
-(def registry-from-spec {:commando/from cmds-builtin/command-from-spec})
+(def registry-from-spec [cmds-builtin/command-from-spec])
 (def test-instruction
   {"source" 42
    "ref" {:commando/from ["source"]}})
 
-(def basic-from-registry {:commando/from cmds-builtin/command-from-spec
-                           :test/add-id test-add-id-command})
+(def basic-from-registry [cmds-builtin/command-from-spec
+                          test-add-id-command])
 (def nested-instruction {"level1" {"level2" {"cmd" {:test/add-id "deep"}}}})
 (def vector-instruction {"items" [{:test/add-id "first"} {:test/add-id "second"}]})
 (def mixed-keys-instruction
@@ -957,16 +957,16 @@
                                        "info" "text"})))
         "Instruction with no commands succeeds")
     (is (commando/ok? (commando/execute basic-from-registry mixed-keys-instruction)) "Mixed data types as keys succeed")
-    (is (commando/failed? (commando/execute {} empty-registry-instruction)))
+    (is (commando/failed? (commando/execute [] empty-registry-instruction)))
     (is (commando/failed? (commando/execute error-registry failing-case-instruction)))
-    (is (commando/failed? (commando/execute {:commando/from cmds-builtin/command-from-spec} invalid-ref-instruction)))
-    (is (not-empty (:errors (commando/execute {:commando/from cmds-builtin/command-from-spec} invalid-ref-instruction))))
-    (is (commando/failed? (commando/execute {:commando/from cmds-builtin/command-from-spec} circular-instruction))
+    (is (commando/failed? (commando/execute [cmds-builtin/command-from-spec] invalid-ref-instruction)))
+    (is (not-empty (:errors (commando/execute [cmds-builtin/command-from-spec] invalid-ref-instruction))))
+    (is (commando/failed? (commando/execute [cmds-builtin/command-from-spec] circular-instruction))
         "Circular dependencies")
-    (is (commando/failed? (commando/execute {:test/invalid invalid-cmd} invalid-validation-instruction)) "Invalid command validation")
-    (is (commando/failed? (commando/execute {:test/throwing throwing-cmd} throwing-recognition-instruction))
+    (is (commando/failed? (commando/execute [invalid-cmd] invalid-validation-instruction)) "Invalid command validation")
+    (is (commando/failed? (commando/execute [throwing-cmd] throwing-recognition-instruction))
         "Command recognition exception")
-    (let [result (commando/execute {:commando/from cmds-builtin/command-from-spec} unexisting-path-instruction)]
+    (let [result (commando/execute [cmds-builtin/command-from-spec] unexisting-path-instruction)]
       (is (commando/failed? result))
       (is (=
             (:errors result)
@@ -974,10 +974,10 @@
               "Commando. Point dependency failed: key ':commando/from' references non-existent path [\"UNEXISTING_PATH\"]",
               :path ["2" :container],
               :command {:commando/from ["UNEXISTING_PATH"]}}])))
-    (is (commando/ok? (commando/execute {:commando/apply cmds-builtin/command-apply-spec} {"plain" {:commando/apply [1 2 3]}}))
+    (is (commando/ok? (commando/execute [cmds-builtin/command-apply-spec] {"plain" {:commando/apply [1 2 3]}}))
         "Missing :=> — identity pass-through via default :get-in driver")
     (is (= [1 2 3]
-           (get-in (commando/execute {:commando/apply cmds-builtin/command-apply-spec} {"plain" {:commando/apply [1 2 3]}}) [:instruction "plain"]))
+           (get-in (commando/execute [cmds-builtin/command-apply-spec] {"plain" {:commando/apply [1 2 3]}}) [:instruction "plain"]))
         "Without :=>, :commando/apply returns its value as-is"))
   (testing "Basic cases"
     (is (= 42 (get-in (commando/execute registry-from-spec test-instruction) [:instruction "ref"]))
@@ -1017,7 +1017,7 @@
                            [:instruction 0 1 2 3 4 5 6 7 8 9 "cmd"])
                    :id)
         "Deep nested command executes")
-    (is (= {"cmd" {:test/add-id "value"}} (:instruction (commando/execute {} empty-registry-instruction)))
+    (is (= {"cmd" {:test/add-id "value"}} (:instruction (commando/execute [] empty-registry-instruction)))
         "empty registry preserves instruction")
     (is (= 200
            (count (filter #(contains? % :id)
@@ -1030,7 +1030,7 @@
                             :id)
                 (range 100)))
     (is (= 5
-           (get-in (commando/execute {:commando/from cmds-builtin/command-from-spec} sum-collection-instruction) [:instruction "0"])))
+           (get-in (commando/execute [cmds-builtin/command-from-spec] sum-collection-instruction) [:instruction "0"])))
     (is (= {"A" 5
             "B" 10
             "result-multiply-1" 20
@@ -1048,11 +1048,11 @@
                                                                   :=> [:get "3"]}}
                                             :=> [:get "2"]}}
                       :=> [:get "1"]}}
-                (commando/execute {:commando/apply cmds-builtin/command-apply-spec})
+                (commando/execute [cmds-builtin/command-apply-spec])
                 :instruction))
         "Commands inside commands are executed correctly")
     (is (= "john"
-           (get-in (:instruction (commando/execute {:commando/from cmds-builtin/command-from-spec}
+           (get-in (:instruction (commando/execute [cmds-builtin/command-from-spec]
                                                    {"source" {:user-name "john"
                                                               :age 25}
                                                     "name" {:commando/from ["source"]
@@ -1060,34 +1060,34 @@
                    ["name"]))
         "Value extracted with :=> [:get] in commando/from using keyword")
     (is (= 25
-           (get-in (:instruction (commando/execute {:commando/from cmds-builtin/command-from-spec}
+           (get-in (:instruction (commando/execute [cmds-builtin/command-from-spec]
                                                    {"source" {"age" 25}
                                                     "age" {:commando/from ["source"]
                                                            :=> [:get "age"]}}))
                    ["age"]))
         "Value extracted with :=> [:get] in commando/from using string")
     (is (= 15
-           (get-in (:instruction (commando/execute {:commando/from cmds-builtin/command-from-spec}
+           (get-in (:instruction (commando/execute [cmds-builtin/command-from-spec]
                                                    {"numbers" [1 2 3 4 5]
                                                     "sum" {:commando/from ["numbers"]
                                                            :=> [:fn #(reduce + %)]}}))
                    ["sum"]))
         "commando/from :=> [:fn] applying function works")
     (is (= 1
-           (get-in (:instruction (commando/execute {:commando/from cmds-builtin/command-from-spec}
+           (get-in (:instruction (commando/execute [cmds-builtin/command-from-spec]
                                                    {"numbers" [1 2 3 4 5]
                                                     "first" {:commando/from ["numbers"]
                                                              :=> [:fn first]}}))
                    ["first"]))
         "commando/from :=> [:fn] applying function works")
-    (is (nil? (get-in (:instruction (commando/execute {:commando/from cmds-builtin/command-from-spec}
+    (is (nil? (get-in (:instruction (commando/execute [cmds-builtin/command-from-spec]
                                                       {"source" {:a 1
                                                                  :b 2}
                                                        "missing" {:commando/from ["source"]
                                                                   :=> [:get :nonexistent]}}))
                       ["missing"]))
         "commando/from :=> [:get] nil returned when key is missing")
-    (is (nil? (get-in (:instruction (commando/execute {:commando/from cmds-builtin/command-from-spec}
+    (is (nil? (get-in (:instruction (commando/execute [cmds-builtin/command-from-spec]
                                                       {"source" {:a 1
                                                                  :b 2}
                                                        "missing" {:commando/from ["source"]
@@ -1095,19 +1095,19 @@
                       ["missing"]))
         "commando/from :=> [:get] nil returned when key is missing")
     (is (= '(20 40 60)
-           (get-in (:instruction (commando/execute {:commando/apply cmds-builtin/command-apply-spec
-                                                    :commando/from cmds-builtin/command-from-spec}
+           (get-in (:instruction (commando/execute [cmds-builtin/command-apply-spec
+                                                    cmds-builtin/command-from-spec]
                                                    {"base" [10 20 30]
                                                     "doubled" {:commando/apply {:commando/from ["base"]}
                                                                :=> [:fn #(map (partial * 2) %)]}}))
                    ["doubled"]))
         "commando/apply works with :=> [:fn] driver")
     (testing "Single command types"
-      (is (= 10 (get-in (commando/execute {:commando/from cmds-builtin/command-from-spec} from-instruction) [:instruction "b"])))
-      (is (= 6 (get-in (commando/execute {:commando/fn cmds-builtin/command-fn-spec} fn-instruction) [:instruction "calc"])))
+      (is (= 10 (get-in (commando/execute [cmds-builtin/command-from-spec] from-instruction) [:instruction "b"])))
+      (is (= 6 (get-in (commando/execute [cmds-builtin/command-fn-spec] fn-instruction) [:instruction "calc"])))
       (is
-       (= 3 (get-in (commando/execute {:commando/apply cmds-builtin/command-apply-spec} apply-instruction) [:instruction "transform"])))
-      (is (contains? (get-in (commando/execute {:test/add-id test-add-id-command} add-id-test-instruction) [:instruction "cmd"])
+       (= 3 (get-in (commando/execute [cmds-builtin/command-apply-spec] apply-instruction) [:instruction "transform"])))
+      (is (contains? (get-in (commando/execute [test-add-id-command] add-id-test-instruction) [:instruction "cmd"])
                      :id)))
     (testing "Mixed command types in single instruction"
       (is (= 100 (get-in (commando/execute full-registry-all mixed-instruction) [:instruction "source"])))
@@ -1143,27 +1143,27 @@
                              [:instruction "parent" "child2"])
                      :id)))
     (testing ":point dependency lookup in set/list cause a failure"
-      (is (and (commando/ok? (commando/execute {:commando/from cmds-builtin/command-from-spec} structure-map-instruction))
+      (is (and (commando/ok? (commando/execute [cmds-builtin/command-from-spec] structure-map-instruction))
                (= 1
-                  (get-in (commando/execute {:commando/from cmds-builtin/command-from-spec} structure-map-instruction)
+                  (get-in (commando/execute [cmds-builtin/command-from-spec] structure-map-instruction)
                           [:instruction "="]))))
-      (is (and (commando/ok? (commando/execute {:commando/from cmds-builtin/command-from-spec} structure-vector-instruction))
+      (is (and (commando/ok? (commando/execute [cmds-builtin/command-from-spec] structure-vector-instruction))
                (= 1
-                  (get-in (commando/execute {:commando/from cmds-builtin/command-from-spec} structure-vector-instruction)
+                  (get-in (commando/execute [cmds-builtin/command-from-spec] structure-vector-instruction)
                           [:instruction "="]))))
-      (is (commando/failed? (commando/execute {:commando/from cmds-builtin/command-from-spec} structure-set-instruction)))
-      (is (commando/failed? (commando/execute {:commando/from cmds-builtin/command-from-spec} structure-list-instruction))))
+      (is (commando/failed? (commando/execute [cmds-builtin/command-from-spec] structure-set-instruction)))
+      (is (commando/failed? (commando/execute [cmds-builtin/command-from-spec] structure-list-instruction))))
     (testing "Navigation with relative path ../"
       (is (= 1
-             (get-in (:instruction (commando/execute {:commando/from cmds-builtin/command-from-spec} relative-path-instruction))
+             (get-in (:instruction (commando/execute [cmds-builtin/command-from-spec] relative-path-instruction))
                      ["2" "container"]))
           "Parent path resolves to correct value")
       (is (= {"container" 1}
-             (get-in (:instruction (commando/execute {:commando/from cmds-builtin/command-from-spec} relative-path-instruction))
+             (get-in (:instruction (commando/execute [cmds-builtin/command-from-spec] relative-path-instruction))
                      ["3" "container"]))
           "Nested parent path with transformation works"))
     (testing "Top-level Vector Instruction"
-      (let [result (commando/execute {:commando/from cmds-builtin/command-from-spec} toplevel-vector-instruction)]
+      (let [result (commando/execute [cmds-builtin/command-from-spec] toplevel-vector-instruction)]
         (is (commando/ok? result) "This type of instruction is also acceptable")
         (is (= [{:value 10} 11 22] (:instruction result))
             "Result of toplevel-vector instruction not match with example")))

--- a/test/unit/commando/driver/builtin_test.cljc
+++ b/test/unit/commando/driver/builtin_test.cljc
@@ -1,0 +1,273 @@
+(ns commando.driver.builtin-test
+  (:require
+   #?(:cljs [cljs.test :refer [deftest is testing]]
+      :clj [clojure.test :refer [deftest is testing]])
+   [commando.commands.builtin :as cmds]
+   [commando.core             :as commando]
+   [commando.impl.executing   :as executing]
+   [clojure.string            :as str]))
+
+;; ====================
+;; :identity (default)
+;; ====================
+
+(deftest identity-driver-test
+  (testing "Explicit :identity"
+    (is (= "Kyiv"
+          (get-in
+            (commando/execute {:commando/from cmds/command-from-spec}
+              {:data "Kyiv"
+               :city {:commando/from [:data] :=> :identity}})
+            [:instruction :city]))))
+
+  (testing "No :=> — default :identity returns full result"
+    (is (= {:nested true}
+          (get-in
+            (commando/execute {:commando/from cmds/command-from-spec}
+              {:data {:nested true}
+               :ref {:commando/from [:data]}})
+            [:instruction :ref]))))
+
+  (testing "String keys (JSON-compatible)"
+    (is (= "Kyiv"
+          (get-in
+            (commando/execute {:commando/from cmds/command-from-spec}
+              {"data" "Kyiv"
+               "city" {"commando-from" ["data"] "=>" ["identity"]}})
+            [:instruction "city"])))))
+
+
+;; ====================
+;; :get-in
+;; ====================
+
+(deftest get-in-driver-test
+  (testing "Explicit :get-in with path"
+    (is (= "Kyiv"
+          (get-in
+            (commando/execute {:commando/from cmds/command-from-spec}
+              {:data {:address {:location {:city "Kyiv"}}}
+               :city {:commando/from [:data] :=> [:get-in [:address :location :city]]}})
+            [:instruction :city]))))
+
+  (testing "String keys (JSON-compatible)"
+    (is (= "Kyiv"
+          (get-in
+            (commando/execute {:commando/from cmds/command-from-spec}
+              {"data" {"address" {"city" "Kyiv"}}
+               "city" {"commando-from" ["data"] "=>" ["get-in" ["address" "city"]]}})
+            [:instruction "city"])))))
+
+;; ====================
+;; :get
+;; ====================
+
+(deftest get-driver-test
+  (testing ":get driver extracts single key"
+    (is (= "John"
+          (get-in
+            (commando/execute {:commando/from cmds/command-from-spec}
+              {:data {:name "John" :age 30}
+               :name {:commando/from [:data] :=> [:get :name]}})
+            [:instruction :name]))))
+
+  (testing "String keys"
+    (is (= "John"
+          (get-in
+            (commando/execute {:commando/from cmds/command-from-spec}
+              {"data" {"name" "John" "age" 30}
+               "name" {"commando-from" ["data"] "=>" ["get" "name"]}})
+            [:instruction "name"])))))
+
+;; ====================
+;; :select-keys
+;; ====================
+
+(deftest select-keys-driver-test
+  (testing ":select-keys filters result keys"
+    (is (= {:name "John" :email "j@x.com"}
+          (get-in
+            (commando/execute {:commando/from cmds/command-from-spec}
+              {:data {:name "John" :age 30 :email "j@x.com" :id 999}
+               :subset {:commando/from [:data] :=> [:select-keys [:name :email]]}})
+            [:instruction :subset]))))
+  (testing "String keys"
+    (is (= {"name" "John" "email" "j@x.com"}
+          (get-in
+            (commando/execute {:commando/from cmds/command-from-spec}
+              {"data" {"name" "John" "age" 30 "email" "j@x.com" "id" 999}
+               "subset" {"commando-from" ["data"] "=>" ["select-keys" ["name" "email"]]}})
+            [:instruction "subset"])))))
+
+;; ====================
+;; :fn
+;; ====================
+
+(deftest fn-driver-test
+  (testing ":fn driver applies function to result"
+    (is (= 7
+          (get-in
+            (commando/execute {:commando/from cmds/command-from-spec}
+              {:data 6
+               :inc {:commando/from [:data] :=> [:fn inc]}})
+            [:instruction :inc]))))
+
+  (testing ":fn with keyword as accessor"
+    (is (= 1
+          (get-in
+            (commando/execute {:commando/from cmds/command-from-spec}
+              {:data {:kwd 1}
+               :val {:commando/from [:data] :=> [:fn :kwd]}})
+            [:instruction :val])))))
+
+;; ====================
+;; :fn with commando/apply and commando/context
+;; ====================
+
+(deftest fn-driver-with-mixed-commands
+  (testing ":fn driver with commando/apply"
+    (is (= 2
+          (get-in
+            (commando/execute {:commando/apply cmds/command-apply-spec
+                               :commando/from cmds/command-from-spec}
+              {:value 1
+               :result {:commando/apply {:commando/from [:value]}
+                        :=> [:fn inc]}})
+            [:instruction :result]))))
+  (testing ":fn driver with commando/context"
+    (let [ctx {:colors {:red "#FF0000" :blue "#0000FF"}}]
+      (is (= "#0000FF"
+            (get-in
+              (commando/execute {:commando/context (cmds/command-context-spec ctx)}
+                {:val {:commando/context [:colors] :=> [:fn :blue]}})
+              [:instruction :val]))))))
+
+;; ====================
+;; :projection
+;; ====================
+
+(deftest projection-driver-test
+  (testing "Rename and reshape fields"
+    (is (= {:user-id "u-101" :city "Kyiv"}
+          (get-in
+            (commando/execute {:commando/from cmds/command-from-spec}
+              {:data {:id "u-101" :address {:location {:city "Kyiv"}}}
+               :result {:commando/from [:data]
+                        :=> [:projection [[:user-id :id]
+                                          [:city [:address :location :city]]]]}})
+            [:instruction :result]))))
+
+  (testing "Simple key passthrough"
+    (is (= {:id "u-101"}
+          (get-in
+            (commando/execute {:commando/from cmds/command-from-spec}
+              {:data {:id "u-101" :extra "stuff"}
+               :result {:commando/from [:data]
+                        :=> [:projection [[:id]]]}})
+            [:instruction :result]))))
+
+  (testing "String keys (JSON-compatible)"
+    (is (= {"user-id" "u-101" "city" "Kyiv"}
+          (get-in
+            (commando/execute {:commando/from cmds/command-from-spec}
+              {"data" {"id" "u-101" "address" {"location" {"city" "Kyiv"}}}
+               "result" {"commando-from" ["data"]
+                         "=>" ["projection" [["user-id" "id"]
+                                             ["city" ["address" "location" "city"]]]]}})
+            [:instruction "result"])))))
+
+;; ====================
+;; Mutation + driver
+;; ====================
+
+(defmethod cmds/command-mutation :driver-test-create-user
+  [_ {:keys [name email]}]
+  {:id (str "u-" (hash name))
+   :name name
+   :email email
+   :status :active
+   :internal-score 42})
+
+(deftest driver-with-mutation-test
+  (testing "Mutation result filtered by :select-keys driver"
+    (let [user (get-in
+                 (commando/execute {:commando/mutation cmds/command-mutation-spec}
+                   {:user {:commando/mutation :driver-test-create-user
+                           :name "John"
+                           :email "j@x.com"
+                           :=> [:select-keys [:id :name :email :status]]}})
+                 [:instruction :user])]
+      (is (= #{:id :name :email :status} (set (keys user))))
+      (is (nil? (:internal-score user))))))
+
+;; ====================
+;; Custom keyword driver
+;; ====================
+
+(defmethod executing/command-driver :uppercase
+  [_ _params applied-result _command-data _instruction _command-path-obj]
+  (if (string? applied-result)
+    (str/upper-case applied-result)
+    applied-result))
+
+(deftest custom-keyword-driver-test
+  (testing "Custom keyword driver without params"
+    (is (= "JOHN"
+          (get-in
+            (commando/execute {:commando/from cmds/command-from-spec}
+              {:data "John"
+               :name {:commando/from [:data] :=> :uppercase}})
+            [:instruction :name])))))
+
+;; ====================
+;; Pipeline
+;; ====================
+
+(deftest pipe-driver-test
+  (testing "Two-step pipeline: get then uppercase"
+    (is (= "KYIV"
+          (get-in
+            (commando/execute {:commando/from cmds/command-from-spec}
+              {:data {:city "Kyiv" :zip "01001"}
+               :result {:commando/from [:data] :=> [[:get :city] :uppercase]}})
+            [:instruction :result]))))
+  
+  (testing "Two-step pipeline: identity and uppercase, first step in pipeline need to be a vector even if it may be simple keyword"
+    (is (= "KYIV"
+          (get-in
+            (commando/execute {:commando/from cmds/command-from-spec}
+              {:data "Kyiv"
+               :result {:commando/from [:data] :=> [[:identity] :uppercase]}})
+            [:instruction :result]))))
+
+  (testing "Three-step pipeline: get-in -> fn -> fn"
+    (is (= 43
+          (get-in
+            (commando/execute {:commando/from cmds/command-from-spec}
+              {:data {:nested {:value 42}}
+               :result {:commando/from [:data] :=> [[:get-in [:nested :value]] [:fn inc]]}})
+            [:instruction :result]))))
+
+  (testing "Pipeline with select-keys then get"
+    (is (= "John"
+          (get-in
+            (commando/execute {:commando/from cmds/command-from-spec}
+              {:data {:name "John" :age 30 :secret "x"}
+               :result {:commando/from [:data] :=> [[:select-keys [:name :age]] [:get :name]]}})
+            [:instruction :result]))))
+
+  (testing "Pipeline with string keys (JSON-compatible)"
+    (is (= "KYIV"
+          (get-in
+            (commando/execute {:commando/from cmds/command-from-spec}
+              {"data" {"city" "Kyiv"}
+               "result" {"commando-from" ["data"] "=>" [["get" "city"] "uppercase"]}})
+            [:instruction "result"]))))
+
+  (testing "Single-step pipeline behaves like regular driver"
+    (is (= "Kyiv"
+          (get-in
+            (commando/execute {:commando/from cmds/command-from-spec}
+              {:data {:city "Kyiv"}
+               :result {:commando/from [:data] :=> [[:get :city]]}})
+            [:instruction :result])))))

--- a/test/unit/commando/driver/builtin_test.cljc
+++ b/test/unit/commando/driver/builtin_test.cljc
@@ -15,7 +15,7 @@
   (testing "Explicit :identity"
     (is (= "Kyiv"
           (get-in
-            (commando/execute {:commando/from cmds/command-from-spec}
+            (commando/execute [cmds/command-from-spec]
               {:data "Kyiv"
                :city {:commando/from [:data] :=> :identity}})
             [:instruction :city]))))
@@ -23,7 +23,7 @@
   (testing "No :=> — default :identity returns full result"
     (is (= {:nested true}
           (get-in
-            (commando/execute {:commando/from cmds/command-from-spec}
+            (commando/execute [cmds/command-from-spec]
               {:data {:nested true}
                :ref {:commando/from [:data]}})
             [:instruction :ref]))))
@@ -31,7 +31,7 @@
   (testing "String keys (JSON-compatible)"
     (is (= "Kyiv"
           (get-in
-            (commando/execute {:commando/from cmds/command-from-spec}
+            (commando/execute [cmds/command-from-spec]
               {"data" "Kyiv"
                "city" {"commando-from" ["data"] "=>" ["identity"]}})
             [:instruction "city"])))))
@@ -45,7 +45,7 @@
   (testing "Explicit :get-in with path"
     (is (= "Kyiv"
           (get-in
-            (commando/execute {:commando/from cmds/command-from-spec}
+            (commando/execute [cmds/command-from-spec]
               {:data {:address {:location {:city "Kyiv"}}}
                :city {:commando/from [:data] :=> [:get-in [:address :location :city]]}})
             [:instruction :city]))))
@@ -53,7 +53,7 @@
   (testing "String keys (JSON-compatible)"
     (is (= "Kyiv"
           (get-in
-            (commando/execute {:commando/from cmds/command-from-spec}
+            (commando/execute [cmds/command-from-spec]
               {"data" {"address" {"city" "Kyiv"}}
                "city" {"commando-from" ["data"] "=>" ["get-in" ["address" "city"]]}})
             [:instruction "city"])))))
@@ -66,7 +66,7 @@
   (testing ":get driver extracts single key"
     (is (= "John"
           (get-in
-            (commando/execute {:commando/from cmds/command-from-spec}
+            (commando/execute [cmds/command-from-spec]
               {:data {:name "John" :age 30}
                :name {:commando/from [:data] :=> [:get :name]}})
             [:instruction :name]))))
@@ -74,7 +74,7 @@
   (testing "String keys"
     (is (= "John"
           (get-in
-            (commando/execute {:commando/from cmds/command-from-spec}
+            (commando/execute [cmds/command-from-spec]
               {"data" {"name" "John" "age" 30}
                "name" {"commando-from" ["data"] "=>" ["get" "name"]}})
             [:instruction "name"])))))
@@ -87,14 +87,14 @@
   (testing ":select-keys filters result keys"
     (is (= {:name "John" :email "j@x.com"}
           (get-in
-            (commando/execute {:commando/from cmds/command-from-spec}
+            (commando/execute [cmds/command-from-spec]
               {:data {:name "John" :age 30 :email "j@x.com" :id 999}
                :subset {:commando/from [:data] :=> [:select-keys [:name :email]]}})
             [:instruction :subset]))))
   (testing "String keys"
     (is (= {"name" "John" "email" "j@x.com"}
           (get-in
-            (commando/execute {:commando/from cmds/command-from-spec}
+            (commando/execute [cmds/command-from-spec]
               {"data" {"name" "John" "age" 30 "email" "j@x.com" "id" 999}
                "subset" {"commando-from" ["data"] "=>" ["select-keys" ["name" "email"]]}})
             [:instruction "subset"])))))
@@ -107,7 +107,7 @@
   (testing ":fn driver applies function to result"
     (is (= 7
           (get-in
-            (commando/execute {:commando/from cmds/command-from-spec}
+            (commando/execute [cmds/command-from-spec]
               {:data 6
                :inc {:commando/from [:data] :=> [:fn inc]}})
             [:instruction :inc]))))
@@ -115,7 +115,7 @@
   (testing ":fn with keyword as accessor"
     (is (= 1
           (get-in
-            (commando/execute {:commando/from cmds/command-from-spec}
+            (commando/execute [cmds/command-from-spec]
               {:data {:kwd 1}
                :val {:commando/from [:data] :=> [:fn :kwd]}})
             [:instruction :val])))))
@@ -128,8 +128,8 @@
   (testing ":fn driver with commando/apply"
     (is (= 2
           (get-in
-            (commando/execute {:commando/apply cmds/command-apply-spec
-                               :commando/from cmds/command-from-spec}
+            (commando/execute [cmds/command-apply-spec
+                               cmds/command-from-spec]
               {:value 1
                :result {:commando/apply {:commando/from [:value]}
                         :=> [:fn inc]}})
@@ -138,7 +138,7 @@
     (let [ctx {:colors {:red "#FF0000" :blue "#0000FF"}}]
       (is (= "#0000FF"
             (get-in
-              (commando/execute {:commando/context (cmds/command-context-spec ctx)}
+              (commando/execute [(cmds/command-context-spec ctx)]
                 {:val {:commando/context [:colors] :=> [:fn :blue]}})
               [:instruction :val]))))))
 
@@ -150,7 +150,7 @@
   (testing "Rename and reshape fields"
     (is (= {:user-id "u-101" :city "Kyiv"}
           (get-in
-            (commando/execute {:commando/from cmds/command-from-spec}
+            (commando/execute [cmds/command-from-spec]
               {:data {:id "u-101" :address {:location {:city "Kyiv"}}}
                :result {:commando/from [:data]
                         :=> [:projection [[:user-id :id]
@@ -160,7 +160,7 @@
   (testing "Simple key passthrough"
     (is (= {:id "u-101"}
           (get-in
-            (commando/execute {:commando/from cmds/command-from-spec}
+            (commando/execute [cmds/command-from-spec]
               {:data {:id "u-101" :extra "stuff"}
                :result {:commando/from [:data]
                         :=> [:projection [[:id]]]}})
@@ -169,7 +169,7 @@
   (testing "String keys (JSON-compatible)"
     (is (= {"user-id" "u-101" "city" "Kyiv"}
           (get-in
-            (commando/execute {:commando/from cmds/command-from-spec}
+            (commando/execute [cmds/command-from-spec]
               {"data" {"id" "u-101" "address" {"location" {"city" "Kyiv"}}}
                "result" {"commando-from" ["data"]
                          "=>" ["projection" [["user-id" "id"]
@@ -191,7 +191,7 @@
 (deftest driver-with-mutation-test
   (testing "Mutation result filtered by :select-keys driver"
     (let [user (get-in
-                 (commando/execute {:commando/mutation cmds/command-mutation-spec}
+                 (commando/execute [cmds/command-mutation-spec]
                    {:user {:commando/mutation :driver-test-create-user
                            :name "John"
                            :email "j@x.com"
@@ -214,7 +214,7 @@
   (testing "Custom keyword driver without params"
     (is (= "JOHN"
           (get-in
-            (commando/execute {:commando/from cmds/command-from-spec}
+            (commando/execute [cmds/command-from-spec]
               {:data "John"
                :name {:commando/from [:data] :=> :uppercase}})
             [:instruction :name])))))
@@ -227,7 +227,7 @@
   (testing "Two-step pipeline: get then uppercase"
     (is (= "KYIV"
           (get-in
-            (commando/execute {:commando/from cmds/command-from-spec}
+            (commando/execute [cmds/command-from-spec]
               {:data {:city "Kyiv" :zip "01001"}
                :result {:commando/from [:data] :=> [[:get :city] :uppercase]}})
             [:instruction :result]))))
@@ -235,7 +235,7 @@
   (testing "Two-step pipeline: identity and uppercase, first step in pipeline need to be a vector even if it may be simple keyword"
     (is (= "KYIV"
           (get-in
-            (commando/execute {:commando/from cmds/command-from-spec}
+            (commando/execute [cmds/command-from-spec]
               {:data "Kyiv"
                :result {:commando/from [:data] :=> [[:identity] :uppercase]}})
             [:instruction :result]))))
@@ -243,7 +243,7 @@
   (testing "Three-step pipeline: get-in -> fn -> fn"
     (is (= 43
           (get-in
-            (commando/execute {:commando/from cmds/command-from-spec}
+            (commando/execute [cmds/command-from-spec]
               {:data {:nested {:value 42}}
                :result {:commando/from [:data] :=> [[:get-in [:nested :value]] [:fn inc]]}})
             [:instruction :result]))))
@@ -251,7 +251,7 @@
   (testing "Pipeline with select-keys then get"
     (is (= "John"
           (get-in
-            (commando/execute {:commando/from cmds/command-from-spec}
+            (commando/execute [cmds/command-from-spec]
               {:data {:name "John" :age 30 :secret "x"}
                :result {:commando/from [:data] :=> [[:select-keys [:name :age]] [:get :name]]}})
             [:instruction :result]))))
@@ -259,7 +259,7 @@
   (testing "Pipeline with string keys (JSON-compatible)"
     (is (= "KYIV"
           (get-in
-            (commando/execute {:commando/from cmds/command-from-spec}
+            (commando/execute [cmds/command-from-spec]
               {"data" {"city" "Kyiv"}
                "result" {"commando-from" ["data"] "=>" [["get" "city"] "uppercase"]}})
             [:instruction "result"]))))
@@ -267,7 +267,7 @@
   (testing "Single-step pipeline behaves like regular driver"
     (is (= "Kyiv"
           (get-in
-            (commando/execute {:commando/from cmds/command-from-spec}
+            (commando/execute [cmds/command-from-spec]
               {:data {:city "Kyiv"}
                :result {:commando/from [:data] :=> [[:get :city]]}})
             [:instruction :result])))))

--- a/test/unit/commando/impl/registry_test.clj
+++ b/test/unit/commando/impl/registry_test.clj
@@ -13,21 +13,19 @@
             (string/upper-case (:custom/upper m)))
    :dependencies {:mode :none}})
 
-(deftest build-registry-from-map
-  (testing "Build registry from a map of specs"
-    (let [r (registry/build {:commando/from cmds-builtin/command-from-spec
-                             :commando/fn   cmds-builtin/command-fn-spec})]
+(deftest build-registry-from-vector
+  (testing "Build registry from a vector of specs"
+    (let [r (registry/build [cmds-builtin/command-from-spec
+                             cmds-builtin/command-fn-spec])]
       (is (registry/built? r))
-      (is (= #{:commando/from :commando/fn} (set (keys (:registry r)))))
-      (is (= 2 (count (:registry-order r)))))))
+      (is (= #{:commando/from :commando/fn} (set (map :type (:registry r)))))
+      (is (= 2 (count (:registry r)))))))
 
-(deftest build-registry-from-map-with-order
-  (testing "Build registry from a map with explicit order"
-    (let [r (registry/build
-              {:commando/from cmds-builtin/command-from-spec
-               :commando/fn   cmds-builtin/command-fn-spec}
-              {:registry-order [:commando/fn :commando/from]})]
-      (is (= [:commando/fn :commando/from] (:registry-order r))))))
+(deftest build-registry-preserves-order
+  (testing "Build registry preserves vector order"
+    (let [r (registry/build [cmds-builtin/command-fn-spec
+                             cmds-builtin/command-from-spec])]
+      (is (= [:commando/fn :commando/from] (mapv :type (:registry r)))))))
 
 (deftest registry-create-from-vector
   (testing "registry-create accepts a vector and preserves order"
@@ -35,8 +33,7 @@
               [cmds-builtin/command-fn-spec
                cmds-builtin/command-from-spec])]
       (is (registry/built? r))
-      (is (= [:commando/fn :commando/from] (:registry-order r)))
-      (is (= #{:commando/fn :commando/from} (set (keys (:registry r))))))))
+      (is (= [:commando/fn :commando/from] (mapv :type (:registry r)))))))
 
 (deftest registry-create-idempotent
   (testing "Passing an already-built registry returns it unchanged"
@@ -44,46 +41,36 @@
           r2 (commando/registry-create r)]
       (is (identical? r r2)))))
 
-(deftest registry-assoc-adds-spec
-  (testing "registry-assoc adds a new spec to a built registry"
-    (let [r  (commando/registry-create {:commando/from cmds-builtin/command-from-spec})
-          r2 (commando/registry-assoc r :custom/upper custom-spec)]
+(deftest registry-add-adds-spec
+  (testing "registry-add adds a new spec to a built registry"
+    (let [r  (commando/registry-create [cmds-builtin/command-from-spec])
+          r2 (commando/registry-add r custom-spec)]
       (is (registry/built? r2))
-      (is (contains? (:registry r2) :custom/upper))
-      (is (some #{:custom/upper} (:registry-order r2)))
-      (is (contains? (:registry r2) :commando/from)))))
+      (is (some #(= :custom/upper (:type %)) (:registry r2)))
+      (is (some #(= :commando/from (:type %)) (:registry r2))))))
 
-(deftest registry-assoc-replaces-spec
-  (testing "registry-assoc replaces an existing spec"
-    (let [r   (commando/registry-create {:commando/from cmds-builtin/command-from-spec
-                                         :custom/upper  custom-spec})
+(deftest registry-add-replaces-spec
+  (testing "registry-add replaces an existing spec"
+    (let [r   (commando/registry-create [cmds-builtin/command-from-spec
+                                         custom-spec])
           new-spec (assoc custom-spec :apply (fn [_ _ m] (string/lower-case (:custom/upper m))))
-          r2  (commando/registry-assoc r :custom/upper new-spec)]
-      (is (= (get-in r2 [:registry :custom/upper :apply])
-             (:apply new-spec))))))
+          r2  (commando/registry-add r new-spec)]
+      (is (= (:apply new-spec)
+             (:apply (first (filter #(= :custom/upper (:type %)) (:registry r2)))))))))
 
-(deftest registry-dissoc-removes-spec
-  (testing "registry-dissoc removes a spec from registry"
-    (let [r  (commando/registry-create {:commando/from cmds-builtin/command-from-spec
-                                        :custom/upper custom-spec})
-          r2 (commando/registry-dissoc r :custom/upper)]
+(deftest registry-remove-removes-spec
+  (testing "registry-remove removes a spec from registry"
+    (let [r  (commando/registry-create [cmds-builtin/command-from-spec
+                                        custom-spec])
+          r2 (commando/registry-remove r :custom/upper)]
       (is (registry/built? r2))
-      (is (not (contains? (:registry r2) :custom/upper)))
-      (is (not (some #{:custom/upper} (:registry-order r2))))
-      (is (contains? (:registry r2) :commando/from)))))
+      (is (not (some #(= :custom/upper (:type %)) (:registry r2))))
+      (is (some #(= :commando/from (:type %)) (:registry r2))))))
 
 (deftest registry-execute-with-vector
   (testing "Execute works when registry was created from a vector"
     (let [result (commando/execute
                    [cmds-builtin/command-from-spec]
-                   {"a" 1 "b" {:commando/from ["a"]}})]
-      (is (commando/ok? result))
-      (is (= {"a" 1 "b" 1} (:instruction result))))))
-
-(deftest registry-execute-with-map
-  (testing "Execute works when registry was created from a map"
-    (let [result (commando/execute
-                   {:commando/from cmds-builtin/command-from-spec}
                    {"a" 1 "b" {:commando/from ["a"]}})]
       (is (commando/ok? result))
       (is (= {"a" 1 "b" 1} (:instruction result))))))


### PR DESCRIPTION
# CHANGELOG.md

**BREAKING** REDESIGNED `:=` / `"="` with the new **Driver system** `:=>` / `"=>"`. The old keys are removed. Migration:
```clojure
:= :name              → :=> [:get :name],
:= [:a :b]            → :=> [:get-in [:a :b]],
:= (fn [result] ...)  → :=> [:fn (fn [result] ...)].
"=" "name"            → "=>" ["get" "name"],
```

Built-in drivers: `:identity` (default), `:get`, `:get-in`, `:select-keys`, `:projection`, `:fn`. Supports pipelines (`[[:get :city] :uppercase]`) and custom drivers via `commando.impl.executing/command-driver` multimethod. See [README](./README.md) for details.

# README.md


### Drivers (Post-Processing)

Drivers provide a **data-driven** way to post-process command results. After a command's `:apply` function produces a raw result, the driver transforms it before the value is placed back into the instruction.

A driver is declared via the `:=>` key (or `"=>"` for string-key/JSON maps) on any command, using a **vector DSL**:

```clojure
;; Vector form — [driver-name & params]
{:commando/.. :=> [:get :name]}
{:commando/.. :=> [:get-in [:address :city]]}
{:commando/.. :=> [:select-keys [:name :email]]}
{:commando/.. :=> [:fn inc]}
;; Keyword form — driver with no params
{:commando/.. :=> :my-custom-driver}
;; Pipeline — first element is a vector, steps are chained left-to-right
{:commando/.. :=> [[:get :address] [:get-in [:location :city]] :uppercase]}
```

If no `:=>` is specified, the default driver is `:get-in` with no params, which acts as identity (pass-through).

```clojure
(commando/execute
 [commands-builtin/command-from-spec]
 {:data {:name "John" :age 30 :email "john@example.com" :internal-id 999}
  :subset {:commando/from [:data]
           :=> [:select-keys [:name :email]]}})
;; => {:data {...}, :subset {:name "John", :email "john@example.com"}}
```

#### Built-in Drivers

**`:identity`** — pass-thought behavior (enabled by default):

```clojure
{:commando/from [:data] :=> :identity}
;; {:name "John" :age 30}  => {:name "John" :age 30}
```

**`:get`** — extract a single key from the result:

```clojure
{:commando/from [:data] :=> [:get :name]}
;; {:name "John" :age 30}  =>  "John"
```

**`:get-in`** — extract a value at a deep path (also the default driver):

```clojure
{:commando/from [:data] :=> [:get-in [:address :location :city]]}
;; {:address {:location {:city "Kyiv"}}}  =>  "Kyiv"
```

**`:select-keys`** — select a subset of keys:

```clojure
{:commando/from [:data] :=> [:select-keys [:name :email]]}
;; {:name "John" :age 30 :email "j@e.com"}  =>  {:name "John" :email "j@e.com"}
```

**`:fn`** — apply an arbitrary function (for cases when you need runtime transforms):

```clojure
{:commando/from [:data] :=> [:fn inc]}
{:commando/from [:data] :=> [:fn #(reduce + %)]}
```

**`:projection`** — rename and reshape fields (pure data, no function transforms):

```clojure
{:commando/from [:data]
 :=> [:projection [[:user-id :id]
                   [:user-name [:profile :full-name]]
                   [:city [:address :location :city]]]]}
;; Each field spec: [output-key]
;;                   [output-key source-key-or-path]
```

Full projection example:

```clojure
(commando/execute
  [commands-builtin/command-from-spec]
  {:data {:id "u-101"
          :profile {:full-name "John Doe"}
          :address {:location {:city "kyiv"} :zip "01001"}
          :metadata {:labels ["important" "urgent"]}}
   :result {:commando/from [:data]
            :=> [:projection [[:user-id :id]
                              [:user-name [:profile :full-name]]
                              [:city [:address :location :city]]
                              [:tags [:metadata :labels]]]]}})
;; => {:data {...}
;;     :result {:user-id "u-101"
;;              :user-name "John Doe"
;;              :city "kyiv"
;;              :tags ["important" "urgent"]}}
```

#### Pipeline

When the first element of `:=>` is itself a vector, the entire value is treated as a **pipeline** — a sequence of driver steps chained left-to-right. Each step's output becomes the next step's input:

```clojure
(commando/execute
  [commands-builtin/command-from-spec]
  {:data {:profile {:name "john doe"} :age 30 :secret "x"}
   ;; Step 1: get :profile → {:name "john doe"}
   ;; Step 2: get :name    → "john doe"
   ;; Step 3: uppercase    → "JOHN DOE"
   :result {:commando/from [:data]
            :=> [[:get :profile] [:get :name] :uppercase]}})
;; => {:data {...}, :result "JOHN DOE"}
```

Each step in the pipeline can be:
- A **vector** `[:driver-name & params]` — e.g. `[:get :name]`, `[:get-in [:a :b]]`, `[:fn inc]`
- A **keyword** `:driver-name` — shorthand for a parameterless driver, e.g. `:uppercase`
- A **string** `"driver-name"` — for JSON compatibility, keywordized at runtime

Pipeline works with JSON string keys too:

```clojure
{"data" {"city" "kyiv"}
 "result" {"commando-from" ["data"] "=>" [["get" "city"] "uppercase"]}}
```

#### Custom Drivers

Drivers use Clojure's multimethod system. Define a new driver by extending `commando.impl.executing/command-driver`:

```clojure
(require '[commando.impl.executing :as commando-executing])

(defmethod commando-executing/command-driver :uppercase
  [_driver-name _driver-params applied-result _command-data _instruction _command-path-obj]
  (if (string? applied-result)
    (clojure.string/upper-case applied-result)
    applied-result))

;; Usage:
{:commando/from [:data] :=> :uppercase}
```

The driver function receives six arguments:
1. `driver-name` — keyword (dispatch value)
2. `driver-params` — seq of parameters from the `:=>` vector (`nil` for keyword-only drivers)
3. `applied-result` — the value returned by `:apply`
4. `command-data` — the original command map before `:apply` ran
5. `instruction` — the full instruction map
6. `command-path-obj` — `CommandMapPath` object

#### Drivers and JSON Compatibility

All built-in driver declarations (except `:fn`) are plain data — keywords, strings, and vectors — making them fully serializable to JSON, EDN, or Transit:

```clojure
;; JSON-compatible instruction with drivers
{"data" {"name" "John" "age" 30}
 "name" {"commando-from" ["data"]
         "=>" ["get" "name"]}}

;; Pipeline in JSON
{"data" {"address" {"city" "kyiv"}}
 "result" {"commando-from" ["data"]
           "=>" [["get-in" ["address" "city"]] "uppercase"]}}
```

String driver names are automatically keywordized at runtime.
